### PR TITLE
Fix G4 USART PHAL

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -3,6 +3,7 @@ Completion:
 
 CompileFlags:
   CompilationDatabase: firmware/build
+  Remove: [-fanalyzer]
 
 Index:
   Background: Build

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -131,7 +131,7 @@ uint16_t PHAL_DMA_getRemaining(PHAL_DMA_Handle_t *handle) {
         return 0;
     }
 
-    return PHAL_DMA_priv_getLength(handle->channel);
+    return PHAL_DMA_priv_getRemainingLength(handle->channel);
 }
 
 bool PHAL_DMA_isBusy(PHAL_DMA_Handle_t *handle) {

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -126,6 +126,14 @@ bool PHAL_DMA_setLength(PHAL_DMA_Handle_t *handle, uint16_t length) {
     return true;
 }
 
+uint16_t PHAL_DMA_getRemaining(PHAL_DMA_Handle_t *handle) {
+    if (handle == nullptr || handle->channel == nullptr) {
+        return 0;
+    }
+
+    return PHAL_DMA_priv_getLength(handle->channel);
+}
+
 bool PHAL_DMA_isBusy(PHAL_DMA_Handle_t *handle) {
     if (handle == nullptr || handle->channel == nullptr) {
         return false;

--- a/firmware/common/phal_G4/dma/dma.h
+++ b/firmware/common/phal_G4/dma/dma.h
@@ -112,6 +112,12 @@ bool PHAL_DMA_setMemAddress(PHAL_DMA_Handle_t *handle, uint32_t address);
 bool PHAL_DMA_setLength(PHAL_DMA_Handle_t *handle, uint16_t length);
 
 /**
+ * @brief Number of elements still left to transfer on this channel
+ * @return elements outstanding, or 0 if handle was never successfully init-ed
+ */
+uint16_t PHAL_DMA_getRemaining(PHAL_DMA_Handle_t *handle);
+
+/**
  * @brief Check whether the channel is currently enabled (transfer in
  * progress, or in circular mode, running continuously)
  *

--- a/firmware/common/phal_G4/dma/dma_priv.c
+++ b/firmware/common/phal_G4/dma/dma_priv.c
@@ -134,3 +134,9 @@ void PHAL_DMA_priv_setLength(DMA_Channel_TypeDef *channel, uint16_t length) {
     // CNDTR = Channel Number of Data to Transfer Register
     channel->CNDTR = length;
 }
+
+uint16_t PHAL_DMA_priv_getLength(DMA_Channel_TypeDef *channel) {
+    // Hardware decrements CNDTR after every element, so it reads back as the
+    // count still outstanding rather than the count originally programmed
+    return (uint16_t)channel->CNDTR;
+}

--- a/firmware/common/phal_G4/dma/dma_priv.c
+++ b/firmware/common/phal_G4/dma/dma_priv.c
@@ -135,7 +135,7 @@ void PHAL_DMA_priv_setLength(DMA_Channel_TypeDef *channel, uint16_t length) {
     channel->CNDTR = length;
 }
 
-uint16_t PHAL_DMA_priv_getLength(DMA_Channel_TypeDef *channel) {
+uint16_t PHAL_DMA_priv_getRemainingLength(DMA_Channel_TypeDef *channel) {
     // Hardware decrements CNDTR after every element, so it reads back as the
     // count still outstanding rather than the count originally programmed
     return (uint16_t)channel->CNDTR;

--- a/firmware/common/phal_G4/dma/dma_priv.h
+++ b/firmware/common/phal_G4/dma/dma_priv.h
@@ -50,6 +50,9 @@ void PHAL_DMA_priv_setMemAddress(DMA_Channel_TypeDef *channel, uint32_t address)
 /// Write the transfer length (CNDTR)
 void PHAL_DMA_priv_setLength(DMA_Channel_TypeDef *channel, uint16_t length);
 
+/// Read how many elements are still outstanding (CNDTR)
+uint16_t PHAL_DMA_priv_getLength(DMA_Channel_TypeDef *channel);
+
 /// True if the transfer-complete flag is currently set for (periph, channel_idx)
 bool PHAL_DMA_priv_readCompleteFlag(DMA_TypeDef *periph, uint8_t channel_idx);
 

--- a/firmware/common/phal_G4/dma/dma_priv.h
+++ b/firmware/common/phal_G4/dma/dma_priv.h
@@ -51,7 +51,7 @@ void PHAL_DMA_priv_setMemAddress(DMA_Channel_TypeDef *channel, uint32_t address)
 void PHAL_DMA_priv_setLength(DMA_Channel_TypeDef *channel, uint16_t length);
 
 /// Read how many elements are still outstanding (CNDTR)
-uint16_t PHAL_DMA_priv_getLength(DMA_Channel_TypeDef *channel);
+uint16_t PHAL_DMA_priv_getRemainingLength(DMA_Channel_TypeDef *channel);
 
 /// True if the transfer-complete flag is currently set for (periph, channel_idx)
 bool PHAL_DMA_priv_readCompleteFlag(DMA_TypeDef *periph, uint8_t channel_idx);

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -35,6 +35,10 @@ bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t
     bool tx_ready = PHAL_DMA_init(&usart_state[idx].tx_dma);
     bool rx_ready = PHAL_DMA_init(&usart_state[idx].rx_dma);
 
+    if (tx_ready && rx_ready) {
+        PHAL_USART_priv_enableIrqs(idx);
+    }
+
     return tx_ready && rx_ready;
 }
 
@@ -54,7 +58,6 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
         return false;
     }
 
-    // Ensure flags are cleared & DMA configured
     PHAL_DMA_Handle_t *tx_dma = &usart_state[idx].tx_dma;
     bool stopped     = PHAL_DMA_stop(tx_dma);
     bool length_set  = PHAL_DMA_setLength(tx_dma, len);
@@ -65,10 +68,8 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
         return false;
     }
 
-    // After DMA enabled, mark channel as busy
     usart_state[idx].tx_busy = true;
 
-    // Start transmission
     PHAL_USART_priv_startTx(PHAL_USART_priv_periph(idx));
 
     return true;
@@ -89,17 +90,12 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len, bool co
     ssize_t idx = periph;
     USART_TypeDef *hw = PHAL_USART_priv_periph(idx);
 
-    // Quiesce the receiver before touching the channel. With RE and DMAR off,
-    // no byte can be latched while we retarget it, which is what makes the
-    // flush below safe from a byte arriving mid-sequence.
     PHAL_USART_priv_stopRx(hw);
 
     usart_state[idx].cont_rx = cont;
     usart_state[idx].rxfer_size = len;
     usart_state[idx].rx_len = 0;
 
-    // Channel must be disabled to set address/length. Same reasoning as txDMA
-    // above: run every step, then report whether they all actually succeeded.
     PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
     bool stopped     = PHAL_DMA_stop(rx_dma);
     bool address_set = PHAL_DMA_setMemAddress(rx_dma, (uint32_t)data);
@@ -175,15 +171,9 @@ bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len)
     return true;
 }
 
-/// Service the USART's own interrupt: transmission complete and/or IDLE line.
 static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
     USART_TypeDef *periph = PHAL_USART_priv_periph(idx);
 
-    // TX completion comes from the USART, not from the DMA. The DMA reports
-    // done once its last write reaches TDR, with one byte still in TDR and
-    // another mid-shift - up to two frame times before the wire goes quiet.
-    // Releasing the caller there lets it overwrite the buffer or re-enable RE
-    // while data is still going out.
     if (PHAL_USART_priv_txCompleteActive(periph)) {
         PHAL_USART_priv_finishTx(periph);
         usart_state[idx].tx_busy = false;
@@ -193,11 +183,6 @@ static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
         return;
     }
 
-    // Clear IDLE up front. The re-arm below plus an application callback of
-    // arbitrary length can easily outlast the gap to the next frame, and an
-    // IDLE latched during that window has to survive this handler - clearing
-    // at the end would discard it, leaving the channel un-rearmed so the next
-    // frame lands at a stale offset.
     PHAL_USART_priv_clearIdle(periph);
 
     PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
@@ -210,30 +195,20 @@ static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
     usart_state[idx].rx_busy = false;
 
     if (usart_state[idx].cont_rx) {
-        // Same ordering rule as PHAL_USART_rx: receiver off, retarget, flush,
-        // then live again. Leaving RE and DMAR on across the re-arm lets a
-        // byte land in RDR while the channel is disabled (and a second one
-        // raise ORE, which stalls the receiver entirely); that byte would then
-        // be handed to data[0] of the next frame.
         PHAL_USART_priv_stopRx(periph);
         PHAL_DMA_setLength(rx_dma, usart_state[idx].rxfer_size);
         PHAL_USART_priv_flushRx(periph);
-        // restart clears stale channel flags so a prior TEIF can't stall re-arm.
         PHAL_DMA_restart(rx_dma);
+
         usart_state[idx].rx_busy = true;
         PHAL_USART_priv_startRx(periph);
     } else {
         PHAL_USART_priv_stopRx(periph);
     }
 
-    // Last, so the channel is already armed for the next frame and a slow
-    // callback costs reception time rather than a whole frame.
     PHAL_USART_rxCallback(idx, received);
 }
 
-/// On TX DMA completion, release the channel. tx_busy is left alone - it is
-/// cleared by the USART's transmission-complete interrupt, which is the point
-/// the frame has actually finished going out.
 static void PHAL_USART_HandleDMA(PHAL_USART_Idx_t idx) {
     if (PHAL_USART_priv_txDmaComplete(idx)) {
         PHAL_DMA_stop(&usart_state[idx].tx_dma);

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -6,8 +6,9 @@
 typedef struct {
     PHAL_DMA_Handle_t tx_dma;    /*!< TX DMA handle (built in init) */
     PHAL_DMA_Handle_t rx_dma;    /*!< RX DMA handle (built in init) */
-    volatile uint32_t rxfer_size; /*!< configured RX length (for continuous re-arm) */
-    volatile bool tx_busy;       /*!< set when a TX is in flight, cleared by the DMA ISR */
+    volatile uint16_t rxfer_size; /*!< configured RX length (for continuous re-arm) */
+    volatile uint16_t rx_len;    /*!< bytes actually received in the last completed frame */
+    volatile bool tx_busy;       /*!< set when a TX is in flight, cleared by the USART TC ISR */
     volatile bool rx_busy;       /*!< set while a frame is in flight, cleared by the IDLE-line ISR */
     bool cont_rx;                /*!< continuous vs one-shot reception */
 } PHAL_USART_state_t;
@@ -28,11 +29,13 @@ bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t
     PHAL_USART_priv_configure(idx, baud_rate, clock_rate);
     PHAL_USART_priv_buildDma(idx, &usart_state[idx].tx_dma, &usart_state[idx].rx_dma);
 
-    if (!PHAL_DMA_init(&usart_state[idx].tx_dma) || !PHAL_DMA_init(&usart_state[idx].rx_dma)) {
-        return false;
-    }
+    // Both, not short-circuited: a failed TX claim must not leave the RX
+    // handle uninitialized, since that failure mode is silent until the first
+    // rx call returns false for no visible reason.
+    bool tx_ready = PHAL_DMA_init(&usart_state[idx].tx_dma);
+    bool rx_ready = PHAL_DMA_init(&usart_state[idx].rx_dma);
 
-    return true;
+    return tx_ready && rx_ready;
 }
 
 /**
@@ -41,27 +44,34 @@ bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t
  * @param periph Which USART peripheral to transmit on
  * @param data Buffer to send
  * @param len Number of bytes to send
- * @return true if every DMA reconfiguration step succeeded, false otherwise
+ * @return true if every DMA reconfiguration step succeeded, false if a
+ *         transmission is already in flight or a step failed
  */
-bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len) {
+bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
     ssize_t idx = periph;
 
-    usart_state[idx].tx_busy = true;
+    if (usart_state[idx].tx_busy) {
+        return false;
+    }
 
-    // Re-target the TX channel at this buffer (channel must be disabled to set
-    // length/address); restart clears stale flags and starts the transfer.
-    // Run every step regardless of earlier ones failing - skipping restart
-    // after a partial reconfiguration would leave the channel worse off, not
-    // better - then report whether they all actually succeeded.
+    // Ensure flags are cleared & DMA configured
     PHAL_DMA_Handle_t *tx_dma = &usart_state[idx].tx_dma;
     bool stopped     = PHAL_DMA_stop(tx_dma);
     bool length_set  = PHAL_DMA_setLength(tx_dma, len);
     bool address_set = PHAL_DMA_setMemAddress(tx_dma, (uint32_t)data);
     bool restarted   = PHAL_DMA_restart(tx_dma);
 
+    if (!(stopped && length_set && address_set && restarted)) {
+        return false;
+    }
+
+    // After DMA enabled, mark channel as busy
+    usart_state[idx].tx_busy = true;
+
+    // Start transmission
     PHAL_USART_priv_startTx(PHAL_USART_priv_periph(idx));
 
-    return stopped && length_set && address_set && restarted;
+    return true;
 }
 
 /**
@@ -75,35 +85,58 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len) {
  *             PHAL_USART_rxCallback after each.
  * @return true if every DMA reconfiguration step succeeded, false otherwise
  */
-bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len, bool cont) {
+bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len, bool cont) {
     ssize_t idx = periph;
+    USART_TypeDef *hw = PHAL_USART_priv_periph(idx);
+
+    // Quiesce the receiver before touching the channel. With RE and DMAR off,
+    // no byte can be latched while we retarget it, which is what makes the
+    // flush below safe from a byte arriving mid-sequence.
+    PHAL_USART_priv_stopRx(hw);
 
     usart_state[idx].cont_rx = cont;
     usart_state[idx].rxfer_size = len;
-    usart_state[idx].rx_busy = true;
+    usart_state[idx].rx_len = 0;
 
-    // Channel must be disabled to set address/length; restart clears stale
-    // flags and starts reception. Same reasoning as txDMA above: run every
-    // step, then report whether they all actually succeeded.
+    // Channel must be disabled to set address/length. Same reasoning as txDMA
+    // above: run every step, then report whether they all actually succeeded.
     PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
     bool stopped     = PHAL_DMA_stop(rx_dma);
     bool address_set = PHAL_DMA_setMemAddress(rx_dma, (uint32_t)data);
     bool length_set  = PHAL_DMA_setLength(rx_dma, len);
-    bool restarted   = PHAL_DMA_restart(rx_dma);
 
-    PHAL_USART_priv_startRx(PHAL_USART_priv_periph(idx));
+    PHAL_USART_priv_flushRx(hw);
 
-    return stopped && address_set && length_set && restarted;
+    bool restarted = PHAL_DMA_restart(rx_dma);
+
+    if (!(stopped && address_set && length_set && restarted)) {
+        return false;
+    }
+
+    usart_state[idx].rx_busy = true;
+    PHAL_USART_priv_startRx(hw);
+
+    return true;
 }
 
 /**
- * @brief Check whether a DMA transmission is still in progress.
+ * @brief Check whether a transmission is still in progress.
  *
  * @param periph Which USART peripheral to check
  * @return true if a transmission is in flight, false otherwise
  */
 bool PHAL_USART_txBusy(PHAL_USART_Idx_t periph) {
     return usart_state[periph].tx_busy;
+}
+
+/**
+ * @brief Number of bytes received in the last completed frame.
+ *
+ * @param periph Which USART peripheral to query
+ * @return byte count, valid once PHAL_USART_rxCallback has fired
+ */
+uint16_t PHAL_USART_rxCount(PHAL_USART_Idx_t periph) {
+    return usart_state[periph].rx_len;
 }
 
 /**
@@ -114,7 +147,7 @@ bool PHAL_USART_txBusy(PHAL_USART_Idx_t periph) {
  * @param len Number of bytes to send
  * @return true if the transfer completed, false if it failed to start
  */
-bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len) {
+bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
     if (!PHAL_USART_tx(periph, data, len)) return false;
 
     while (PHAL_USART_txBusy(periph)) {
@@ -132,7 +165,7 @@ bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len)
  * @param len Number of bytes to receive
  * @return true if the reception completed, false if it failed to start
  */
-bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len) {
+bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
     if (!PHAL_USART_rx(periph, data, len, false)) return false;
 
     while (usart_state[periph].rx_busy) {
@@ -142,42 +175,75 @@ bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len)
     return true;
 }
 
-/// On the IDLE line, finish the frame, re-arm if continuous, and notify the app.
+/// Service the USART's own interrupt: transmission complete and/or IDLE line.
 static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
     USART_TypeDef *periph = PHAL_USART_priv_periph(idx);
 
-    if (PHAL_USART_priv_idleActive(periph)) {
-        PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
-        PHAL_DMA_stop(rx_dma);
-        usart_state[idx].rx_busy = false;
-
-        if (usart_state[idx].cont_rx) {
-            // The transfer length has counted down to 0; reload it and re-arm.
-            // restart clears stale channel flags so a prior TEIF can't stall re-arm.
-            PHAL_DMA_setLength(rx_dma, usart_state[idx].rxfer_size);
-            PHAL_DMA_restart(rx_dma);
-        } else {
-            PHAL_USART_priv_stopRx(periph);
-        }
-
-        PHAL_USART_rxCallback(idx);
+    // TX completion comes from the USART, not from the DMA. The DMA reports
+    // done once its last write reaches TDR, with one byte still in TDR and
+    // another mid-shift - up to two frame times before the wire goes quiet.
+    // Releasing the caller there lets it overwrite the buffer or re-enable RE
+    // while data is still going out.
+    if (PHAL_USART_priv_txCompleteActive(periph)) {
+        PHAL_USART_priv_finishTx(periph);
+        usart_state[idx].tx_busy = false;
     }
 
-    PHAL_USART_priv_clearStatusFlags(periph);
+    if (!PHAL_USART_priv_idleActive(periph)) {
+        return;
+    }
+
+    // Clear IDLE up front. The re-arm below plus an application callback of
+    // arbitrary length can easily outlast the gap to the next frame, and an
+    // IDLE latched during that window has to survive this handler - clearing
+    // at the end would discard it, leaving the channel un-rearmed so the next
+    // frame lands at a stale offset.
+    PHAL_USART_priv_clearIdle(periph);
+
+    PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
+    PHAL_DMA_stop(rx_dma);
+
+    // CNDTR counts down, so the shortfall against the configured length is
+    // what actually landed. Read it before the re-arm reloads the count.
+    uint16_t received = (uint16_t)(usart_state[idx].rxfer_size - PHAL_DMA_getRemaining(rx_dma));
+    usart_state[idx].rx_len = received;
+    usart_state[idx].rx_busy = false;
+
+    if (usart_state[idx].cont_rx) {
+        // Same ordering rule as PHAL_USART_rx: receiver off, retarget, flush,
+        // then live again. Leaving RE and DMAR on across the re-arm lets a
+        // byte land in RDR while the channel is disabled (and a second one
+        // raise ORE, which stalls the receiver entirely); that byte would then
+        // be handed to data[0] of the next frame.
+        PHAL_USART_priv_stopRx(periph);
+        PHAL_DMA_setLength(rx_dma, usart_state[idx].rxfer_size);
+        PHAL_USART_priv_flushRx(periph);
+        // restart clears stale channel flags so a prior TEIF can't stall re-arm.
+        PHAL_DMA_restart(rx_dma);
+        usart_state[idx].rx_busy = true;
+        PHAL_USART_priv_startRx(periph);
+    } else {
+        PHAL_USART_priv_stopRx(periph);
+    }
+
+    // Last, so the channel is already armed for the next frame and a slow
+    // callback costs reception time rather than a whole frame.
+    PHAL_USART_rxCallback(idx, received);
 }
 
-/// On TX DMA completion, mark the transmitter free and clear the channel flags.
+/// On TX DMA completion, release the channel. tx_busy is left alone - it is
+/// cleared by the USART's transmission-complete interrupt, which is the point
+/// the frame has actually finished going out.
 static void PHAL_USART_HandleDMA(PHAL_USART_Idx_t idx) {
     if (PHAL_USART_priv_txDmaComplete(idx)) {
         PHAL_DMA_stop(&usart_state[idx].tx_dma);
-        usart_state[idx].tx_busy = false;
     }
     PHAL_USART_priv_clearTxDmaFlags(idx);
 }
 
-[[gnu::weak]]
-void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph) {
+[[gnu::weak]] void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph, uint16_t len) {
     (void)periph;
+    (void)len;
 }
 
 /* DMA transfer-complete interrupt handlers (TX channels) */
@@ -209,7 +275,7 @@ void DMA1_Channel2_IRQHandler(void) {
     PHAL_USART_HandleDMA(USART3_IDX);
 }
 
-/* USART interrupt handlers (IDLE line) */
+/* USART interrupt handlers (IDLE line + transmission complete) */
 void USART1_IRQHandler(void) {
     PHAL_USART_HandleIRQ(USART1_IDX);
 }

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -186,6 +186,12 @@ static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
     PHAL_USART_priv_clearIdle(periph);
 
     PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
+
+    // Enabling RE on an already-idle line can raise IDLE before the first byte reaches DMA
+    if (PHAL_DMA_getRemaining(rx_dma) == usart_state[idx].rxfer_size) {
+        return;
+    }
+
     PHAL_DMA_stop(rx_dma);
 
     // CNDTR counts down, so the shortfall against the configured length is

--- a/firmware/common/phal_G4/usart/usart.h
+++ b/firmware/common/phal_G4/usart/usart.h
@@ -34,28 +34,39 @@ bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t
 /**
  * @brief Start a transmission using DMA.
  *
+ * Fails rather than truncating a transfer already in flight - poll
+ * PHAL_USART_txBusy() (or use PHAL_USART_txBlocking) before calling again.
+ *
  * @param periph Which USART peripheral to transmit on
  * @param data The address of the data to send
- * @param len Number of bytes
- * @return true if every DMA reconfiguration step succeeded, false otherwise
+ * @param len Number of bytes.
+ * @return true if every DMA reconfiguration step succeeded, false if a
+ *         transmission is already in flight or a step failed
  */
-bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len);
+bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len);
 
 /**
  * @brief Start a reception using DMA of a specific length.
  *
  * @param periph Which USART peripheral to receive on
  * @param data The address to put the received data
- * @param len Number of bytes
+ * @param len Maximum number of bytes (the buffer size). A frame shorter than
+ *            this still completes on the IDLE line; the actual count is
+ *            reported to PHAL_USART_rxCallback. uint16_t because that is the
+ *            DMA's transfer counter width.
  * @param cont Enable continuous RX using the IDLE-line interrupt. When set, call
  *             this function once and the HAL keeps receiving frames of the same
- *             length, invoking PHAL_USART_rxCallback after each.
+ *             maximum length, invoking PHAL_USART_rxCallback after each.
  * @return true if every DMA reconfiguration step succeeded, false otherwise
  */
-bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len, bool cont);
+bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len, bool cont);
 
 /**
  * @brief Returns whether the USART peripheral is currently transmitting data.
+ *
+ * Tracks the USART's own transmission-complete flag, so it stays true until
+ * the last bit has left the wire - not merely until the DMA has finished
+ * writing to the data register.
  *
  * @param periph Which USART peripheral to check
  * @return true if the peripheral is currently sending a message, false otherwise
@@ -63,37 +74,53 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len, bool co
 bool PHAL_USART_txBusy(PHAL_USART_Idx_t periph);
 
 /**
+ * @brief Number of bytes received in the last completed frame.
+ *
+ * The IDLE line ends a frame whenever the sender stops, which may be short of
+ * the length passed to PHAL_USART_rx. Anything past this count in the buffer
+ * is leftover from an earlier frame.
+ *
+ * @param periph Which USART peripheral to query
+ * @return byte count, valid once PHAL_USART_rxCallback has fired (or
+ *         PHAL_USART_rxBlocking has returned)
+ */
+uint16_t PHAL_USART_rxCount(PHAL_USART_Idx_t periph);
+
+/**
  * @brief Transmit data, blocking until the transfer completes.
  *
- * Starts a DMA transmission (see PHAL_USART_tx) and busy-waits until it
- * finishes. Do not call from an ISR.
+ * Starts a DMA transmission (see PHAL_USART_tx) and busy-waits until the
+ * USART reports the frame fully shifted out. Do not call from an ISR.
  *
  * @param periph Which USART peripheral to transmit on
  * @param data Buffer to send
  * @param len Number of bytes to send
  * @return true if the transfer completed, false if it failed to start
  */
-bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len);
+bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len);
 
 /**
  * @brief Receive data, blocking until a one-shot reception completes.
  *
  * Starts a one-shot DMA reception (see PHAL_USART_rx) and busy-waits until
- * the IDLE-line ISR signals the frame is complete. Do not call from an ISR.
+ * the IDLE-line ISR signals the frame is complete. Call PHAL_USART_rxCount()
+ * afterwards for the byte count. Do not call from an ISR.
  *
  * @param periph Which USART peripheral to receive on
  * @param data Buffer to receive into
- * @param len Number of bytes to receive
+ * @param len Maximum number of bytes to receive
  * @return true if the reception completed, false if it failed to start
  */
-bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint32_t len);
+bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len);
 
 /**
  * @brief Weak callback invoked when a full RX frame is received. Override in
  *        application code. Runs in ISR context, so keep it light.
  *
  * @param periph Which USART peripheral received the frame
+ * @param len Number of bytes in this frame. Bytes past this offset in the
+ *            buffer are stale and must not be decoded.
  */
-extern void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph);
+extern void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph, uint16_t len);
 
 #endif // __PHAL_G4_USART_H__

--- a/firmware/common/phal_G4/usart/usart_priv.c
+++ b/firmware/common/phal_G4/usart/usart_priv.c
@@ -36,6 +36,22 @@ static const PHAL_USART_HwMap_t USART_MAP[NUM_USART] = {
     },
 };
 
+// Every RX error flag, plus IDLE. ICR is write-1-to-clear, so clearing a flag
+// that is not set is harmless (RM0440, USART_ICR).
+static constexpr uint32_t USART_PRIV_RX_FLAG_CLEAR_MSK =
+      USART_ICR_IDLECF | USART_ICR_ORECF | USART_ICR_NECF
+    | USART_ICR_FECF | USART_ICR_PECF;
+
+static inline uint32_t enterCritical(void) {
+    uint32_t previous_interrupt_mask = __get_PRIMASK();
+    __disable_irq();
+    return previous_interrupt_mask;
+}
+
+static inline void exitCritical(uint32_t previous_interrupt_mask) {
+    __set_PRIMASK(previous_interrupt_mask);
+}
+
 USART_TypeDef *PHAL_USART_priv_periph(ssize_t idx) {
     return USART_MAP[idx].periph;
 }
@@ -64,11 +80,17 @@ void PHAL_USART_priv_configure(ssize_t idx, uint32_t baud_rate, uint32_t clock_r
     // Per original source code
     periph->BRR = (clock_rate + (baud_rate / 2U)) / baud_rate;
 
-    // IDLE-line interrupt signals RX frame completion.
+    // IDLE-line interrupt signals RX frame completion. TCIE stays off until a
+    // transmission is actually armed, so an idle transmitter cannot raise the
+    // shared USART interrupt.
     periph->CR1 |= USART_CR1_IDLEIE;
 
-    // Enable USART 
+    // Enable USART
     periph->CR1 |= USART_CR1_UE;
+
+    // ISR comes out of reset with TC already set; drop it (and any RX flags)
+    // so the first startTx does not see a completion that never happened.
+    periph->ICR = USART_PRIV_RX_FLAG_CLEAR_MSK | USART_ICR_TCCF;
 
     NVIC_ClearPendingIRQ(map->irq);
     NVIC_EnableIRQ(map->irq);
@@ -102,36 +124,65 @@ void PHAL_USART_priv_buildDma(ssize_t idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_H
 }
 
 void PHAL_USART_priv_startTx(USART_TypeDef *periph) {
+    uint32_t mask = enterCritical();
+
+    // Drop the previous frame's TC before arming TCIE, otherwise enabling the
+    // interrupt would immediately re-report a completion that already happened.
+    periph->ICR = USART_ICR_TCCF;
+    periph->CR1 |= USART_CR1_TE | USART_CR1_TCIE;
+
+    // Last: the channel is already enabled, so this is the point the first
+    // byte can actually move.
     periph->CR3 |= USART_CR3_DMAT;
-    periph->CR1 |= USART_CR1_TE;
+
+    exitCritical(mask);
+}
+
+bool PHAL_USART_priv_txCompleteActive(USART_TypeDef *periph) {
+    return (periph->ISR & USART_ISR_TC) != 0U && (periph->CR1 & USART_CR1_TCIE) != 0U;
+}
+
+void PHAL_USART_priv_finishTx(USART_TypeDef *periph) {
+    uint32_t mask = enterCritical();
+
+    periph->CR1 &= ~USART_CR1_TCIE;
+    periph->ICR = USART_ICR_TCCF;
+
+    exitCritical(mask);
 }
 
 void PHAL_USART_priv_startRx(USART_TypeDef *periph) {
-    // clear RXNE and discard the byte in data register
-    periph->RQR |= USART_RQR_RXFRQ; 
-
-    // write-1-to-clear status & error flags
-    periph->ICR = USART_ICR_ORECF;
+    uint32_t mask = enterCritical();
 
     periph->CR1 |= USART_CR1_RE;
     periph->CR3 |= USART_CR3_DMAR;
+
+    exitCritical(mask);
 }
 
 void PHAL_USART_priv_stopRx(USART_TypeDef *periph) {
+    uint32_t mask = enterCritical();
+
     periph->CR1 &= ~USART_CR1_RE;
     periph->CR3 &= ~USART_CR3_DMAR;
 
-    (void)periph->RDR;
+    exitCritical(mask);
+}
+
+void PHAL_USART_priv_flushRx(USART_TypeDef *periph) {
+    // RQR is write-only; RXFRQ discards whatever is in RDR and clears RXNE so
+    // no stale byte is waiting when the DMA channel is enabled.
+    periph->RQR = USART_RQR_RXFRQ;
+
+    periph->ICR = USART_PRIV_RX_FLAG_CLEAR_MSK;
 }
 
 bool PHAL_USART_priv_idleActive(USART_TypeDef *periph) {
     return (periph->ISR & USART_ISR_IDLE) != 0U;
 }
 
-void PHAL_USART_priv_clearStatusFlags(USART_TypeDef *periph) {
-    // ICR is write-1-to-clear; clearing a flag that is not set is harmless.
-    periph->ICR = USART_ICR_IDLECF | USART_ICR_ORECF | USART_ICR_NECF
-                | USART_ICR_FECF | USART_ICR_PECF;
+void PHAL_USART_priv_clearIdle(USART_TypeDef *periph) {
+    periph->ICR = USART_ICR_IDLECF;
 }
 
 bool PHAL_USART_priv_txDmaComplete(ssize_t idx) {

--- a/firmware/common/phal_G4/usart/usart_priv.c
+++ b/firmware/common/phal_G4/usart/usart_priv.c
@@ -36,15 +36,16 @@ static const PHAL_USART_HwMap_t USART_MAP[NUM_USART] = {
     },
 };
 
-// Every RX error flag, plus IDLE. ICR is write-1-to-clear, so clearing a flag
-// that is not set is harmless (RM0440, USART_ICR).
 static constexpr uint32_t USART_PRIV_RX_FLAG_CLEAR_MSK =
       USART_ICR_IDLECF | USART_ICR_ORECF | USART_ICR_NECF
     | USART_ICR_FECF | USART_ICR_PECF;
 
 static inline uint32_t enterCritical(void) {
     uint32_t previous_interrupt_mask = __get_PRIMASK();
+
+    // sets PRIMASK to 1
     __disable_irq();
+
     return previous_interrupt_mask;
 }
 
@@ -62,41 +63,28 @@ void PHAL_USART_priv_configure(ssize_t idx, uint32_t baud_rate, uint32_t clock_r
 
     // Pulse the peripheral reset
     *map->rcc_reset_rg |= map->rcc_reset_msk;
+    (void)*map->rcc_reset_rg;
     *map->rcc_reset_rg &= ~map->rcc_reset_msk;
 
     // Enable the register clock
     *map->rcc_enable_rg |= map->rcc_enable_msk;
-
-    // Dummy read to ensure the register write has taken effect
     (void)*map->rcc_enable_rg;
 
-    // Reset control registers. We want:
+    // Reset control registers.
     // 8 data bits, no parity, 1 stop bit,
     // 16x oversampling, disabled peripheral
     periph->CR1 = 0U;
     periph->CR2 = 0U;
     periph->CR3 = 0U;
 
-    // Per original source code
     periph->BRR = (clock_rate + (baud_rate / 2U)) / baud_rate;
 
-    // IDLE-line interrupt signals RX frame completion. TCIE stays off until a
-    // transmission is actually armed, so an idle transmitter cannot raise the
-    // shared USART interrupt.
     periph->CR1 |= USART_CR1_IDLEIE;
-
-    // Enable USART
     periph->CR1 |= USART_CR1_UE;
 
-    // ISR comes out of reset with TC already set; drop it (and any RX flags)
-    // so the first startTx does not see a completion that never happened.
+    // writing to TCCF clears TC in ISR, which we use to determine
+    // if a byte has finished shifting out on the wire
     periph->ICR = USART_PRIV_RX_FLAG_CLEAR_MSK | USART_ICR_TCCF;
-
-    NVIC_ClearPendingIRQ(map->irq);
-    NVIC_EnableIRQ(map->irq);
-
-    NVIC_ClearPendingIRQ(map->tx_dma_irq);
-    NVIC_EnableIRQ(map->tx_dma_irq);
 }
 
 void PHAL_USART_priv_buildDma(ssize_t idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_Handle_t *rx_dma) {
@@ -124,31 +112,36 @@ void PHAL_USART_priv_buildDma(ssize_t idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_H
 }
 
 void PHAL_USART_priv_startTx(USART_TypeDef *periph) {
+    // dont let interrupt occur during this code
     uint32_t mask = enterCritical();
 
-    // Drop the previous frame's TC before arming TCIE, otherwise enabling the
-    // interrupt would immediately re-report a completion that already happened.
+    // clear TC
     periph->ICR = USART_ICR_TCCF;
+
+    // rearm TC and enable transmitter
     periph->CR1 |= USART_CR1_TE | USART_CR1_TCIE;
 
-    // Last: the channel is already enabled, so this is the point the first
-    // byte can actually move.
+    // enable dmat
     periph->CR3 |= USART_CR3_DMAT;
 
     exitCritical(mask);
 }
 
-bool PHAL_USART_priv_txCompleteActive(USART_TypeDef *periph) {
-    return (periph->ISR & USART_ISR_TC) != 0U && (periph->CR1 & USART_CR1_TCIE) != 0U;
-}
-
 void PHAL_USART_priv_finishTx(USART_TypeDef *periph) {
     uint32_t mask = enterCritical();
 
+    // disarm TC interrupt
     periph->CR1 &= ~USART_CR1_TCIE;
+
+    // clear TC
     periph->ICR = USART_ICR_TCCF;
 
     exitCritical(mask);
+}
+
+
+bool PHAL_USART_priv_txCompleteActive(USART_TypeDef *periph) {
+    return (periph->ISR & USART_ISR_TC) != 0U && (periph->CR1 & USART_CR1_TCIE) != 0U;
 }
 
 void PHAL_USART_priv_startRx(USART_TypeDef *periph) {
@@ -194,6 +187,15 @@ bool PHAL_USART_priv_txDmaComplete(ssize_t idx) {
 void PHAL_USART_priv_clearTxDmaFlags(ssize_t idx) {
     const PHAL_DMA_Wiring_t *wiring = USART_MAP[idx].tx_wiring;
     uint32_t shift = 4U * (wiring->channel_idx - 1U);
-    // CGIF clears TCIF/HTIF/TEIF/GIF for the channel (RM0440, DMA_IFCR).
     wiring->periph->IFCR = DMA_IFCR_CGIF1 << shift;
+}
+
+void PHAL_USART_priv_enableIrqs(ssize_t idx) {
+    const PHAL_USART_HwMap_t *map = &USART_MAP[idx];
+    
+    NVIC_ClearPendingIRQ(map->irq);
+    NVIC_EnableIRQ(map->irq);
+
+    NVIC_ClearPendingIRQ(map->tx_dma_irq);
+    NVIC_EnableIRQ(map->tx_dma_irq);
 }

--- a/firmware/common/phal_G4/usart/usart_priv.c
+++ b/firmware/common/phal_G4/usart/usart_priv.c
@@ -82,6 +82,10 @@ void PHAL_USART_priv_configure(ssize_t idx, uint32_t baud_rate, uint32_t clock_r
     periph->CR1 |= USART_CR1_IDLEIE;
     periph->CR1 |= USART_CR1_UE;
 
+    // Keep TX enabled once the USART is initialized
+    // Establishes the required idle-high (mark) level on a TX pin
+    periph->CR1 |= USART_CR1_TE;
+
     // writing to TCCF clears TC in ISR, which we use to determine
     // if a byte has finished shifting out on the wire
     periph->ICR = USART_PRIV_RX_FLAG_CLEAR_MSK | USART_ICR_TCCF;

--- a/firmware/common/phal_G4/usart/usart_priv.h
+++ b/firmware/common/phal_G4/usart/usart_priv.h
@@ -28,13 +28,12 @@ void PHAL_USART_priv_configure(ssize_t idx, uint32_t baud_rate, uint32_t clock_r
 /// Fill the TX and RX DMA handles from the hardware map.
 void PHAL_USART_priv_buildDma(ssize_t idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_Handle_t *rx_dma);
 
-
 void PHAL_USART_priv_startTx(USART_TypeDef *periph);
-
-bool PHAL_USART_priv_txCompleteActive(USART_TypeDef *periph);
 
 /// Acknowledge transmission-complete: disable TCIE and clear ISR.TC.
 void PHAL_USART_priv_finishTx(USART_TypeDef *periph);
+
+bool PHAL_USART_priv_txCompleteActive(USART_TypeDef *periph);
 
 /// Enable the receiver and its DMA request line (CR1.RE, CR3.DMAR).
 void PHAL_USART_priv_startRx(USART_TypeDef *periph);
@@ -56,5 +55,7 @@ bool PHAL_USART_priv_txDmaComplete(ssize_t idx);
 
 /// Clear all interrupt flags for the slot's TX DMA channel.
 void PHAL_USART_priv_clearTxDmaFlags(ssize_t idx);
+
+void PHAL_USART_priv_enableIrqs(ssize_t idx);
 
 #endif // __PHAL_G4_USART_PRIV_H__

--- a/firmware/common/phal_G4/usart/usart_priv.h
+++ b/firmware/common/phal_G4/usart/usart_priv.h
@@ -7,50 +7,49 @@
 #include "common/phal_G4/phal_G4.h"
 #include "common/phal_G4/usart/usart.h" // PHAL_USART_Idx_t
 
-// Fixed hardware wiring for one UART. Every field is dictated by the datasheet
-// (RM0440 / STM32G474) or the DMA HAL's own wiring constants. This table is
-// the single source of truth that replaces the old per-peripheral RCC, NVIC,
-// and DMA-channel switch ladders.
 typedef struct {
     volatile uint32_t *rcc_enable_rg;   /*!< RCC enable register for this UART */
     uint32_t rcc_enable_msk;            /*!< enable bit within rcc_enable_rg */
     volatile uint32_t *rcc_reset_rg;    /*!< RCC reset register for this UART */
     uint32_t rcc_reset_msk;             /*!< reset bit within rcc_reset_rg */
     USART_TypeDef *periph;              /*!< peripheral instance */
-    IRQn_Type irq;                      /*!< USART global interrupt (carries IDLE) */
+    IRQn_Type irq;                      /*!< USART global interrupt (carries IDLE and TC) */
     IRQn_Type tx_dma_irq;               /*!< NVIC line for the TX DMA channel */
     const PHAL_DMA_Wiring_t *tx_wiring; /*!< fixed DMA wiring for TX (see dma_wiring.h) */
     const PHAL_DMA_Wiring_t *rx_wiring; /*!< fixed DMA wiring for RX (see dma_wiring.h) */
 } PHAL_USART_HwMap_t;
 
-/*
- * Private register-level operations. All USART/DMA/RCC/NVIC bit-and-register
- * business lives here so the public source (usart.c) reads as pure orchestration.
- */
-
 /// @return the peripheral instance for a slot (used by the interrupt handlers).
 USART_TypeDef *PHAL_USART_priv_periph(ssize_t idx);
 
-/// Enable the clock, program 8N1 + baud, and enable the IDLE + TX-DMA interrupts.
+/// Enable the clock, program 8N1 + baud, and enable the USART + TX-DMA interrupts.
 void PHAL_USART_priv_configure(ssize_t idx, uint32_t baud_rate, uint32_t clock_rate);
 
 /// Fill the TX and RX DMA handles from the hardware map.
 void PHAL_USART_priv_buildDma(ssize_t idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_Handle_t *rx_dma);
 
-/// Enable the transmitter and its DMA request line (CR3.DMAT, CR1.TE).
+
 void PHAL_USART_priv_startTx(USART_TypeDef *periph);
+
+bool PHAL_USART_priv_txCompleteActive(USART_TypeDef *periph);
+
+/// Acknowledge transmission-complete: disable TCIE and clear ISR.TC.
+void PHAL_USART_priv_finishTx(USART_TypeDef *periph);
 
 /// Enable the receiver and its DMA request line (CR1.RE, CR3.DMAR).
 void PHAL_USART_priv_startRx(USART_TypeDef *periph);
 
-/// Disable the receiver (CR1.RE) — used to end a one-shot reception.
+/// Disable the receiver and its DMA request line (CR1.RE, CR3.DMAR).
 void PHAL_USART_priv_stopRx(USART_TypeDef *periph);
+
+/// Discard anything sitting in RDR and clear IDLE plus every RX error flag.
+void PHAL_USART_priv_flushRx(USART_TypeDef *periph);
 
 /// @return true if the IDLE-line flag is set (an RX frame just completed).
 bool PHAL_USART_priv_idleActive(USART_TypeDef *periph);
 
-/// Clear the IDLE and RX error status flags (write-1-to-clear).
-void PHAL_USART_priv_clearStatusFlags(USART_TypeDef *periph);
+/// Clear the IDLE flag alone (write-1-to-clear).
+void PHAL_USART_priv_clearIdle(USART_TypeDef *periph);
 
 /// @return true if the slot's TX DMA channel signalled transfer complete.
 bool PHAL_USART_priv_txDmaComplete(ssize_t idx);

--- a/firmware/source/g4_testing/usart_test.c
+++ b/firmware/source/g4_testing/usart_test.c
@@ -41,10 +41,11 @@ static constexpr uint32_t USART1_TEST_BAUD = 115200u;
 static constexpr uint32_t USART2_TEST_BAUD = 9600u;
 static constexpr uint32_t USART3_TEST_BAUD = 500000u;
 
-static constexpr uint32_t FRAME_LEN = 16;
+static constexpr uint16_t FRAME_LEN = 16;
 static uint8_t tx_buf[FRAME_LEN];
 static uint8_t rx_buf[FRAME_LEN];
 static volatile uint32_t rx_frame_success_count;
+static volatile uint16_t rx_frame_len; //!< length reported by the last rxCallback
 
 // Every subtest below except the per-peripheral roundtrips runs on USART2.
 static constexpr PHAL_USART_Idx_t TEST_PERIPH = USART2_IDX;
@@ -67,6 +68,8 @@ volatile uint32_t usart_failed_expected;
 volatile uint32_t usart_failed_actual;
 
 static constexpr uint32_t TIMEOUT_MARKER = 0xFFFFFFFFu;
+// Distinguishes "wrong frame length" from a byte-index mismatch in usart_failed_detail.
+static constexpr uint32_t LENGTH_MARKER = 0xFFFFFFFEu;
 
 // These spin loops are raw instruction counts, not a hardware timer, so their
 // real-world duration is inversely proportional to core clock. Scale the
@@ -121,8 +124,14 @@ static bool record_failure(usart_subtest_id_t id, uint32_t detail, uint32_t expe
     return false;
 }
 
-static bool buffers_equal(usart_subtest_id_t id, const uint8_t *expected, const uint8_t *actual, uint32_t len) {
-    for (uint32_t i = 0; i < len; i++) {
+static bool buffers_equal(usart_subtest_id_t id, const uint8_t *expected, const uint8_t *actual, uint16_t len) {
+    // The HAL reports how many bytes actually landed, so a short frame (or one
+    // shifted by a stale byte) is caught here instead of silently comparing
+    // against leftovers from the previous subtest.
+    if (rx_frame_len != len)
+        return record_failure(id, LENGTH_MARKER, len, rx_frame_len);
+
+    for (uint16_t i = 0; i < len; i++) {
         if (expected[i] != actual[i])
             return record_failure(id, i, expected[i], actual[i]);
     }
@@ -329,8 +338,9 @@ int main(void) {
     return 0;
 }
 
-void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph) {
+void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph, uint16_t len) {
     (void)periph;
+    rx_frame_len = len;
     rx_frame_success_count++;
 }
 

--- a/firmware/source/g4_testing/usart_test.c
+++ b/firmware/source/g4_testing/usart_test.c
@@ -88,23 +88,31 @@ static uint32_t compute_timeout_iters(uint32_t ahb_clock_hz) {
 // here (9600)) so a genuine HAL bug times out instead of hanging the board.
 static bool wait_for_frame(uint32_t before) {
     uint32_t i = usart_test_timeout_iters;
-    while (rx_frame_success_count == before && --i);
+    while (rx_frame_success_count == before && --i) {
+        __NOP();
+    }
     return i != 0;
 }
 
 // Same idea, for the one case that isn't waiting on rx_frame_success_count.
 static bool wait_for_tx_free(PHAL_USART_Idx_t periph) {
     uint32_t i = usart_test_timeout_iters;
-    while (PHAL_USART_txBusy(periph) && --i);
+    while (PHAL_USART_txBusy(periph) && --i) {
+        __NOP();
+    }
     return i != 0;
 }
 
 static void delay_iters(uint32_t n) {
-    while (n--) __asm__("nop");
+    while (n--) {
+        __NOP();
+    }
 }
 
 static void fill_pattern(uint8_t *buf, uint32_t len, uint8_t seed) {
-    for (uint32_t i = 0; i < len; i++) buf[i] = (uint8_t)(seed + i);
+    for (uint32_t i = 0; i < len; i++) {
+        buf[i] = (uint8_t)(seed + i);
+    }
 }
 
 // tx_buf gets a fresh known pattern, rx_buf is zeroed so a leftover byte from
@@ -127,12 +135,14 @@ static bool buffers_equal(usart_subtest_id_t id, const uint8_t *expected, const 
     // The HAL reports how many bytes actually landed, so a short frame (or one
     // shifted by a stale byte) is caught here instead of silently comparing
     // against leftovers from the previous subtest.
-    if (rx_frame_len != len)
+    if (rx_frame_len != len) {
         return record_failure(id, LENGTH_MARKER, len, rx_frame_len);
+    }
 
     for (uint16_t i = 0; i < len; i++) {
-        if (expected[i] != actual[i])
+        if (expected[i] != actual[i]) {
             return record_failure(id, i, expected[i], actual[i]);
+        }
     }
     return true;
 }
@@ -145,14 +155,17 @@ static bool buffers_equal(usart_subtest_id_t id, const uint8_t *expected, const 
 static bool run_roundtrip(PHAL_USART_Idx_t periph, usart_subtest_id_t id, uint8_t seed) {
     prep_frame(seed);
 
-    if (!PHAL_USART_rx(periph, rx_buf, FRAME_LEN, false))
+    if (!PHAL_USART_rx(periph, rx_buf, FRAME_LEN, false)) {
         return record_failure(id, TIMEOUT_MARKER, 0, 0); // rxDMA failed to arm
+    }
 
     uint32_t before = rx_frame_success_count;
-    if (!PHAL_USART_tx(periph, tx_buf, FRAME_LEN))
+    if (!PHAL_USART_tx(periph, tx_buf, FRAME_LEN)) {
         return record_failure(id, TIMEOUT_MARKER, 0, 1); // txDMA failed to start
-    if (!wait_for_frame(before))
+    }
+    if (!wait_for_frame(before)) {
         return record_failure(id, TIMEOUT_MARKER, 0, 2); // frame never arrived
+    }
 
     return buffers_equal(id, tx_buf, rx_buf, FRAME_LEN);
 }
@@ -169,14 +182,17 @@ static bool test_usart3_roundtrip(void) { return run_roundtrip(USART3_IDX, SUBTE
 static bool test_txBl_blocking_send(void) {
     prep_frame(0xD0);
 
-    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false))
+    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false)) {
         return record_failure(SUBTEST_TXBL, TIMEOUT_MARKER, 0, 0);
+    }
 
     uint32_t before = rx_frame_success_count;
-    if (!PHAL_USART_txBlocking(TEST_PERIPH, tx_buf, FRAME_LEN))
+    if (!PHAL_USART_txBlocking(TEST_PERIPH, tx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_TXBL, TIMEOUT_MARKER, 0, 1); // txBl reported failure to start
-    if (!wait_for_frame(before))
+    }
+    if (!wait_for_frame(before)) {
         return record_failure(SUBTEST_TXBL, TIMEOUT_MARKER, 0, 2); // txBl returned before data was actually sent
+    }
 
     return buffers_equal(SUBTEST_TXBL, tx_buf, rx_buf, FRAME_LEN);
 }
@@ -189,10 +205,12 @@ static bool test_txBl_blocking_send(void) {
 static bool test_rxBl_blocking_receive(void) {
     prep_frame(0xE0);
 
-    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN))
+    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_RXBL, TIMEOUT_MARKER, 0, 0);
-    if (!PHAL_USART_rxBlocking(TEST_PERIPH, rx_buf, FRAME_LEN))
+    }
+    if (!PHAL_USART_rxBlocking(TEST_PERIPH, rx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_RXBL, TIMEOUT_MARKER, 0, 1); // rxBl reported failure to start
+    }
 
     return buffers_equal(SUBTEST_RXBL, tx_buf, rx_buf, FRAME_LEN);
 }
@@ -200,18 +218,22 @@ static bool test_rxBl_blocking_receive(void) {
 //! Verify txBusy() is false at rest, true immediately after txDMA starts, and
 //! false again once the TX-DMA-complete ISR runs.
 static bool test_txBusy_tracks_transfer(void) {
-    if (PHAL_USART_txBusy(TEST_PERIPH))
+    if (PHAL_USART_txBusy(TEST_PERIPH)) {
         return record_failure(SUBTEST_TXBUSY, 0, 0, 1); // busy before any transfer was started
+    }
 
     fill_pattern(tx_buf, FRAME_LEN, 0xF0);
-    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN))
+    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_TXBUSY, TIMEOUT_MARKER, 0, 2);
+    }
 
-    if (!PHAL_USART_txBusy(TEST_PERIPH))
+    if (!PHAL_USART_txBusy(TEST_PERIPH)) {
         return record_failure(SUBTEST_TXBUSY, 1, 1, 0); // must be busy right after starting
+    }
 
-    if (!wait_for_tx_free(TEST_PERIPH))
+    if (!wait_for_tx_free(TEST_PERIPH)) {
         return record_failure(SUBTEST_TXBUSY, TIMEOUT_MARKER, 0, 1); // never cleared - TX DMA ISR bug
+    }
 
     return true;
 }
@@ -222,36 +244,47 @@ static bool test_txBusy_tracks_transfer(void) {
  */
 static bool test_oneshot_rx_does_not_rearm(void) {
     prep_frame(0x10);
-    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false))
+    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false)) {
         return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 0);
+    }
 
     uint32_t before = rx_frame_success_count;
-    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN))
+    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 1);
-    if (!wait_for_frame(before))
+    }
+
+    if (!wait_for_frame(before)) {
         return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 2);
-    if (!buffers_equal(SUBTEST_ONESHOT, tx_buf, rx_buf, FRAME_LEN))
+    }
+
+    if (!buffers_equal(SUBTEST_ONESHOT, tx_buf, rx_buf, FRAME_LEN)) {
         return false;
+    }
 
     // Receiver should now be disabled (PHAL_USART_priv_stopRx) - a second frame
     // must be dropped, not silently captured into the stale rx_buf.
     uint32_t after_first = rx_frame_success_count;
     fill_pattern(tx_buf, FRAME_LEN, 0x11);
-    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN))
+    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 3);
+    }
     delay_iters(usart_test_timeout_iters);
-    if (rx_frame_success_count != after_first)
+    if (rx_frame_success_count != after_first) {
         return record_failure(SUBTEST_ONESHOT, 4, after_first, rx_frame_success_count); // captured a frame it shouldn't have
+    }
 
     // Re-arming should cleanly capture the next frame.
     memset(rx_buf, 0, FRAME_LEN);
-    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false))
+    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false)) {
         return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 5);
+    }
     fill_pattern(tx_buf, FRAME_LEN, 0x12);
-    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN))
+    if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 6);
-    if (!wait_for_frame(after_first))
+    }
+    if (!wait_for_frame(after_first)) {
         return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 7); // re-arm after stop failed to start receiving again
+    }
 
     return buffers_equal(SUBTEST_ONESHOT, tx_buf, rx_buf, FRAME_LEN);
 }
@@ -266,22 +299,29 @@ static constexpr uint32_t CONT_RX_FRAMES = 8;
  */
 static bool test_continuous_rx_multiframe(void) {
     memset(rx_buf, 0, FRAME_LEN);
-    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, true))
+    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, true)) {
         return record_failure(SUBTEST_CONTINUOUS, TIMEOUT_MARKER, 0, 0);
+    }
 
     for (uint32_t frame = 0; frame < CONT_RX_FRAMES; frame++) {
         uint32_t before = rx_frame_success_count;
         fill_pattern(tx_buf, FRAME_LEN, (uint8_t)(0x20 + frame));
 
-        if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN))
+        if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
             return record_failure(SUBTEST_CONTINUOUS, frame, 0, 1);
-        if (!wait_for_frame(before))
+        }
+        if (!wait_for_frame(before)) {
             return record_failure(SUBTEST_CONTINUOUS, frame, 0, 2); // re-arm stalled on this frame
+        }
 
-        if (!buffers_equal(SUBTEST_CONTINUOUS, tx_buf, rx_buf, FRAME_LEN))
+        if (!buffers_equal(SUBTEST_CONTINUOUS, tx_buf, rx_buf, FRAME_LEN)) {
             return false;
+        }
 
-        while (PHAL_USART_txBusy(TEST_PERIPH)); // don't overwrite tx_buf until this frame's TX is done
+        // don't overwrite tx_buf until this frame's TX is done
+        while (PHAL_USART_txBusy(TEST_PERIPH)) {
+            __NOP();
+        }
     }
     return true;
 }
@@ -328,7 +368,7 @@ int main(void) {
     PHAL_writeGPIO(LED_RED_PORT, LED_RED_PIN, pass ? 0 : 1);
 
     while (1) {
-        __asm__("nop");
+        __NOP();
     }
 
     return 0;
@@ -342,7 +382,7 @@ void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph, uint16_t len) {
 
 void HardFault_Handler(void) {
     while (1) {
-        __asm__("nop");
+        __NOP();
     }
 }
 

--- a/firmware/source/g4_testing/usart_test.c
+++ b/firmware/source/g4_testing/usart_test.c
@@ -18,7 +18,6 @@
  * Please plug in each of the following TX pins into
  * their corresponding RX pins:
  *   USART1: PA9  (TX) -> PA10 (RX)
- *   USART2: PA2  (TX) -> PA3  (RX)
  *   USART3: PC10 (TX) -> PC11 (RX)
  */
 
@@ -30,16 +29,16 @@ GPIOInitConfig_t gpio_config[] = {
 
     GPIO_INIT_USART1TX_PA9,
     GPIO_INIT_USART1RX_PA10,
-    GPIO_INIT_USART2TX_PA2,
-    GPIO_INIT_USART2RX_PA3,
+
+    // Skip USART2, conflicts with Nucleo
+
     GPIO_INIT_USART3TX_PC10,
     GPIO_INIT_USART3RX_PC11,
 };
 
 // USART1 on APB2; USART2/3 on APB1
 static constexpr uint32_t USART1_TEST_BAUD = 115200u;
-static constexpr uint32_t USART2_TEST_BAUD = 9600u;
-static constexpr uint32_t USART3_TEST_BAUD = 500000u;
+static constexpr uint32_t USART3_TEST_BAUD = 9600u;
 
 static constexpr uint16_t FRAME_LEN = 16;
 static uint8_t tx_buf[FRAME_LEN];
@@ -47,12 +46,11 @@ static uint8_t rx_buf[FRAME_LEN];
 static volatile uint32_t rx_frame_success_count;
 static volatile uint16_t rx_frame_len; //!< length reported by the last rxCallback
 
-// Every subtest below except the per-peripheral roundtrips runs on USART2.
-static constexpr PHAL_USART_Idx_t TEST_PERIPH = USART2_IDX;
+// Every subtest below except the per-peripheral roundtrips runs on USART3
+static constexpr PHAL_USART_Idx_t TEST_PERIPH = USART3_IDX;
 
 typedef enum {
     SUBTEST_USART1_ROUNDTRIP,
-    SUBTEST_USART2_ROUNDTRIP,
     SUBTEST_USART3_ROUNDTRIP,
     SUBTEST_TXBL,
     SUBTEST_RXBL,
@@ -114,6 +112,7 @@ static void fill_pattern(uint8_t *buf, uint32_t len, uint8_t seed) {
 static void prep_frame(uint8_t seed) {
     fill_pattern(tx_buf, FRAME_LEN, seed);
     memset(rx_buf, 0, FRAME_LEN);
+    rx_frame_len = 0;
 }
 
 static bool record_failure(usart_subtest_id_t id, uint32_t detail, uint32_t expected, uint32_t actual) {
@@ -159,7 +158,6 @@ static bool run_roundtrip(PHAL_USART_Idx_t periph, usart_subtest_id_t id, uint8_
 }
 
 static bool test_usart1_roundtrip(void) { return run_roundtrip(USART1_IDX, SUBTEST_USART1_ROUNDTRIP, 0xA0); }
-static bool test_usart2_roundtrip(void) { return run_roundtrip(USART2_IDX, SUBTEST_USART2_ROUNDTRIP, 0xB0); }
 static bool test_usart3_roundtrip(void) { return run_roundtrip(USART3_IDX, SUBTEST_USART3_ROUNDTRIP, 0xC0); }
 
 /**
@@ -295,8 +293,7 @@ typedef struct {
 
 static const usart_subtest_t subtests[NUM_SUBTESTS] = {
     [SUBTEST_USART1_ROUNDTRIP] = {"usart1 roundtrip (APB2, 115200 baud)", test_usart1_roundtrip},
-    [SUBTEST_USART2_ROUNDTRIP] = {"usart2 roundtrip (APB1, 9600 baud)", test_usart2_roundtrip},
-    [SUBTEST_USART3_ROUNDTRIP] = {"usart3 roundtrip (APB1, 500000 baud)", test_usart3_roundtrip},
+    [SUBTEST_USART3_ROUNDTRIP] = {"usart3 roundtrip (APB1, 9600 baud)", test_usart3_roundtrip},
     [SUBTEST_TXBL] = {"txBl blocking send", test_txBl_blocking_send},
     [SUBTEST_RXBL] = {"rxBl blocking receive", test_rxBl_blocking_receive},
     [SUBTEST_TXBUSY] = {"txBusy tracks transfer", test_txBusy_tracks_transfer},
@@ -316,7 +313,6 @@ int main(void) {
     PHAL_writeGPIO(LED_GREEN_PORT, LED_GREEN_PIN, 0);
 
     if (!PHAL_USART_init(USART1_IDX, USART1_TEST_BAUD, PHAL_RCC_getAPB2ClockHz())
-        || !PHAL_USART_init(USART2_IDX, USART2_TEST_BAUD, PHAL_RCC_getAPB1ClockHz())
         || !PHAL_USART_init(USART3_IDX, USART3_TEST_BAUD, PHAL_RCC_getAPB1ClockHz())
     ) {
         HardFault_Handler();

--- a/nix_flake/flake.nix
+++ b/nix_flake/flake.nix
@@ -50,6 +50,7 @@
             })
 
             python
+            mypy
 
             pkg-config
             systemd

--- a/nix_flake/flake.nix
+++ b/nix_flake/flake.nix
@@ -32,6 +32,9 @@
             clang
             libclang
             clang-tools
+            lcov
+            gtest
+            cppcheck
 
             gcc-arm-embedded
             openocd
@@ -68,9 +71,14 @@
               pkgs.dbus
             ]}:$LD_LIBRARY_PATH
 
+            export CC="${pkgs.gcc}/bin/gcc"
+            export CXX="${pkgs.gcc}/bin/g++"
+
             echo "Purdue Electric Racing development environment"
             echo "  CMake:      $(cmake --version | head -n1)"
             echo "  Ninja:      $(ninja --version)"
+            echo "  GCC:        $($CC --version | head -n1)"
+            echo "  G++:        $($CXX --version | head -n1)"
             echo "  ARM GCC:    $(arm-none-eabi-gcc --version | head -n1)"
             echo "  OpenOCD:    $(openocd --version 2>&1 | head -n1)"
             echo "  Python:     $(python --version)"

--- a/nix_flake/flake.nix
+++ b/nix_flake/flake.nix
@@ -61,6 +61,9 @@
             mesa
             libGL
             dbus
+
+            direnv
+            nix-direnv
           ];
 
           shellHook = ''


### PR DESCRIPTION
- Better defense and length tracking
- Enable `USART_CR1_TE` as part of USART init/`PHAL_USART_priv_configure`
- Solve and IDLE/renable bug?
- Testing changes:
  - Can't use USART2 on Nucleo
  - 500000 baud is too fast for loopback
  - Code style: all `if` and `while` have `{}`s and blank `while`s have `__NOP();`
- Also updated nix flake to include the unit testing and cppcheck tools + mypy for python type checking
  