### PR TITLE
G4 DMA HAL improvements: centralized IRQ handling + better integration into other HALs

### DIFF
--- a/firmware/common/phal_G4/adc/adc.c
+++ b/firmware/common/phal_G4/adc/adc.c
@@ -140,10 +140,11 @@ bool PHAL_ADC_readDMA(PHAL_ADC_Handle_t *handle, uint16_t *buffer, uint16_t leng
 
     // (Re)arm the DMA channel: fresh flags, new buffer/length, channel enabled
     handle->dma.params.tx_size = length;
-    if (!PHAL_DMA_setMemAddress(&handle->dma, (uint32_t)buffer)
-        || !PHAL_DMA_restart(&handle->dma)) {
+    if (!PHAL_DMA_setMemAddress(&handle->dma, (uint32_t)buffer)) {
         return false;
     }
+
+    PHAL_DMA_restart(&handle->dma);
 
     handle->busy           = true;
     handle->transfer_error = false;

--- a/firmware/common/phal_G4/adc/adc.c
+++ b/firmware/common/phal_G4/adc/adc.c
@@ -139,10 +139,9 @@ bool PHAL_ADC_readDMA(PHAL_ADC_Handle_t *handle, uint16_t *buffer, uint16_t leng
     }
 
     // (Re)arm the DMA channel: fresh flags, new buffer/length, channel enabled
+    PHAL_DMA_stop(&handle->dma);
     handle->dma.params.tx_size = length;
-    if (!PHAL_DMA_setMemAddress(&handle->dma, (uint32_t)buffer)) {
-        return false;
-    }
+    (void)PHAL_DMA_setMemAddress(&handle->dma, (uint32_t)buffer);
 
     PHAL_DMA_restart(&handle->dma);
 

--- a/firmware/common/phal_G4/adc/adc.c
+++ b/firmware/common/phal_G4/adc/adc.c
@@ -14,6 +14,7 @@
 static PHAL_ADC_Handle_t *g_active_adc[4];
 
 
+// Forward declaration of the DMA callback handler for ADC completion
 static void adc_dma_callback(void *ctx);
 
 

--- a/firmware/common/phal_G4/adc/adc.c
+++ b/firmware/common/phal_G4/adc/adc.c
@@ -13,11 +13,9 @@
 // handle that owns the channel that fired.
 static PHAL_ADC_Handle_t *g_active_adc[4];
 
-/// USART DMA fallback used when DMA1 channel 1 is not owned by ADC1.
-extern void PHAL_USART_DMA1_Channel1_IRQHandler(void) __attribute__((weak));
 
-/// SPI DMA fallback used when DMA2 channel 3 is not owned by ADC4.
-extern void PHAL_SPI_DMA2_Channel3_IRQHandler(void) __attribute__((weak));
+static void adc_dma_callback(void *ctx);
+
 
 /// Map a supported ADC instance to its zero-based active-handle slot.
 static uint8_t adc_instance_index(ADC_TypeDef *instance) {
@@ -71,11 +69,6 @@ static IRQn_Type adc_dma_irqn(ADC_TypeDef *instance) {
     return (IRQn_Type)(base + wiring->channel_idx - 1);
 }
 
-/// Enable the NVIC interrupt for an ADC instance's DMA channel.
-static void adc_nvic_enable(ADC_TypeDef *instance) {
-    NVIC_EnableIRQ(adc_dma_irqn(instance));
-}
-
 // --- transfer plumbing -------------------------------------------------------
 
 /// Atomically claim transfer completion for either polling or interrupt code.
@@ -125,14 +118,14 @@ bool PHAL_ADC_init(PHAL_ADC_Handle_t *handle, const PHAL_ADC_Config_t *config) {
         .mem_inc    = true,
         .tx_isr_en  = true, // transfer-complete interrupt drives the callback
     };
-    if (!PHAL_DMA_init(&handle->dma)) {
+
+    if (!PHAL_DMA_initWithCallback(&handle->dma, adc_dma_callback, handle)) {
         ADC_PRIV_disable(config->instance);
         handle->config = nullptr;
         return false;
     }
 
     g_active_adc[index] = handle;
-    adc_nvic_enable(config->instance);
     return true;
 }
 
@@ -257,35 +250,8 @@ static void adc_dma_irq_handler(PHAL_ADC_Handle_t *handle) {
     }
 }
 
-// These vectors are strong so ADC completion is deterministic. Contested
-// channels delegate to the other PHAL only when no ADC owns that DMA channel;
-// DMA channel claiming prevents both peripherals from being active at once.
-/// Dispatch DMA1 channel 1 to ADC1 or its USART3 RX fallback owner.
-void DMA1_Channel1_IRQHandler(void) {
-    if (g_active_adc[0] != nullptr) {
-        adc_dma_irq_handler(g_active_adc[0]);
-    } else if (PHAL_USART_DMA1_Channel1_IRQHandler != nullptr) {
-        PHAL_USART_DMA1_Channel1_IRQHandler();
-    }
-}
-
-/// Dispatch the ADC2 DMA transfer interrupt.
-void DMA2_Channel1_IRQHandler(void) {
-    adc_dma_irq_handler(g_active_adc[1]);
-}
-
-/// Dispatch the ADC3 DMA transfer interrupt.
-void DMA2_Channel2_IRQHandler(void) {
-    adc_dma_irq_handler(g_active_adc[2]);
-}
-
-/// Dispatch DMA2 channel 3 to ADC4 or its SPI3 TX fallback owner.
-void DMA2_Channel3_IRQHandler(void) {
-    if (g_active_adc[3] != nullptr) {
-        adc_dma_irq_handler(g_active_adc[3]);
-    } else if (PHAL_SPI_DMA2_Channel3_IRQHandler != nullptr) {
-        PHAL_SPI_DMA2_Channel3_IRQHandler();
-    }
+static void adc_dma_callback(void *ctx) {
+    adc_dma_irq_handler((PHAL_ADC_Handle_t *)ctx);
 }
 
 [[gnu::weak]] void PHAL_ADC_conversionCompleteCallback(PHAL_ADC_Handle_t *handle) {

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -182,9 +182,13 @@ void DMA1_Channel4_IRQHandler(void) { dma_dispatch(DMA1, 4); }
 void DMA1_Channel5_IRQHandler(void) { dma_dispatch(DMA1, 5); }
 void DMA1_Channel6_IRQHandler(void) { dma_dispatch(DMA1, 6); }
 void DMA1_Channel7_IRQHandler(void) { dma_dispatch(DMA1, 7); }
+void DMA1_Channel8_IRQHandler(void) { dma_dispatch(DMA1, 8); }
 
 void DMA2_Channel1_IRQHandler(void) { dma_dispatch(DMA2, 1); }
 void DMA2_Channel2_IRQHandler(void) { dma_dispatch(DMA2, 2); }
 void DMA2_Channel3_IRQHandler(void) { dma_dispatch(DMA2, 3); }
 void DMA2_Channel4_IRQHandler(void) { dma_dispatch(DMA2, 4); }
 void DMA2_Channel5_IRQHandler(void) { dma_dispatch(DMA2, 5); }
+void DMA2_Channel6_IRQHandler(void) { dma_dispatch(DMA2, 6); }
+void DMA2_Channel7_IRQHandler(void) { dma_dispatch(DMA2, 7); }
+void DMA2_Channel8_IRQHandler(void) { dma_dispatch(DMA2, 8); }

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -63,6 +63,11 @@ bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle) {
 
     *owner = handle;
 
+    // If the user registered a callback, arm the NVIC line for this channel
+    if (handle->callback.irq_fn != nullptr) {
+        NVIC_EnableIRQ(PHAL_DMA_priv_getIRQn(wiring->periph, wiring->channel_idx));
+    }
+
     return true;
 }
 
@@ -82,6 +87,9 @@ bool PHAL_DMA_deinit(PHAL_DMA_Handle_t *handle) {
 
     PHAL_DMA_priv_disableChannel(handle->channel);
 
+    if (handle->callback.irq_fn != nullptr) {
+        NVIC_DisableIRQ(PHAL_DMA_priv_getIRQn(handle->wiring->periph, handle->wiring->channel_idx));
+    }
 
     *dma_channel_owner_slot(handle->wiring->periph, handle->wiring->channel_idx) = nullptr;
     

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -10,17 +10,16 @@
 #include "common/phal_G4/dma/dma_priv.h"
 
 // Tracks which (periph, channel_idx) pairs are owned by a live handle.
-// Doubles as (a) conflict prevention when claiming a channel and (b) the
-// DMA PHAL's dispatch table for its own IRQ vectors below — this is what
-// lets DMA own every DMAx_ChannelN_IRQHandler while other HALs just
-// register a callback instead of defining competing vectors.
-// Index 0 is unused (channel numbering is 1-8).
-static PHAL_DMA_Handle_t *g_dma1_channel_owner[9];
-static PHAL_DMA_Handle_t *g_dma2_channel_owner[9];
+// Provides conflict prevention when claiming a channel and route IRQs/
+// dispatch registered DMA callbacks.
+// Index is channel number - 1
+static PHAL_DMA_Handle_t *g_dma1_channel_owner[8];
+static PHAL_DMA_Handle_t *g_dma2_channel_owner[8];
 
 static PHAL_DMA_Handle_t **dma_channel_owner_slot(DMA_TypeDef *periph, uint8_t channel_idx) {
     PHAL_DMA_Handle_t **table = (periph == DMA1) ? g_dma1_channel_owner : g_dma2_channel_owner;
-    return &table[channel_idx];
+    uint8_t table_idx = channel_idx - 1;
+    return &table[table_idx];
 }
 
 static bool dma_wiring_is_valid(const PHAL_DMA_Wiring_t *wiring) {

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -207,3 +207,25 @@ void PHAL_DMA_setMemInc(PHAL_DMA_Handle_t *handle, bool mem_inc) {
     handle->params.mem_inc = mem_inc;
     PHAL_DMA_priv_configChannel(handle->channel, handle->wiring, &handle->params);
 }
+
+
+static void dma_dispatch(DMA_TypeDef *periph, uint8_t channel_idx) {
+    PHAL_DMA_Handle_t *handle = *dma_channel_owner_slot(periph, channel_idx);
+    if (handle != nullptr && handle->callback.irq_fn != nullptr) {
+        handle->callback.irq_fn(handle->callback.ctx);
+    }
+}
+
+void DMA1_Channel1_IRQHandler(void) { dma_dispatch(DMA1, 1); }
+void DMA1_Channel2_IRQHandler(void) { dma_dispatch(DMA1, 2); }
+void DMA1_Channel3_IRQHandler(void) { dma_dispatch(DMA1, 3); }
+void DMA1_Channel4_IRQHandler(void) { dma_dispatch(DMA1, 4); }
+void DMA1_Channel5_IRQHandler(void) { dma_dispatch(DMA1, 5); }
+void DMA1_Channel6_IRQHandler(void) { dma_dispatch(DMA1, 6); }
+void DMA1_Channel7_IRQHandler(void) { dma_dispatch(DMA1, 7); }
+
+void DMA2_Channel1_IRQHandler(void) { dma_dispatch(DMA2, 1); }
+void DMA2_Channel2_IRQHandler(void) { dma_dispatch(DMA2, 2); }
+void DMA2_Channel3_IRQHandler(void) { dma_dispatch(DMA2, 3); }
+void DMA2_Channel4_IRQHandler(void) { dma_dispatch(DMA2, 4); }
+void DMA2_Channel5_IRQHandler(void) { dma_dispatch(DMA2, 5); }

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -81,11 +81,7 @@ bool PHAL_DMA_initWithCallback(PHAL_DMA_Handle_t *handle, PHAL_DMA_IRQCallbackFn
     return PHAL_DMA_init(handle);
 }
 
-bool PHAL_DMA_deinit(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return false;
-    }
-
+void PHAL_DMA_deinit(PHAL_DMA_Handle_t *handle) {
     PHAL_DMA_priv_disableChannel(handle->channel);
 
     if (handle->callback.irq_fn != nullptr) {
@@ -97,42 +93,25 @@ bool PHAL_DMA_deinit(PHAL_DMA_Handle_t *handle) {
     handle->channel = nullptr;
     handle->callback.irq_fn = nullptr;
     handle->callback.ctx = nullptr;
-    
-    return true;
 }
 
-bool PHAL_DMA_start(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return false;
-    }
-
+void PHAL_DMA_start(PHAL_DMA_Handle_t *handle) {
     PHAL_DMA_priv_enableChannel(handle->channel);
-    return true;
 }
 
-bool PHAL_DMA_stop(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return false;
-    }
-
+void PHAL_DMA_stop(PHAL_DMA_Handle_t *handle) {
     PHAL_DMA_priv_disableChannel(handle->channel);
-    return true;
 }
 
-bool PHAL_DMA_restart(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return false;
-    }
-
+void PHAL_DMA_restart(PHAL_DMA_Handle_t *handle) {
     PHAL_DMA_priv_disableChannel(handle->channel);
     PHAL_DMA_priv_clearFlags(handle->wiring->periph, handle->wiring->channel_idx);
     PHAL_DMA_priv_setLength(handle->channel, handle->params.tx_size);
     PHAL_DMA_priv_enableChannel(handle->channel);
-    return true;
 }
 
 bool PHAL_DMA_setMemAddress(PHAL_DMA_Handle_t *handle, uint32_t address) {
-    if (handle == nullptr || handle->channel == nullptr || PHAL_DMA_priv_isChannelEnabled(handle->channel)) {
+    if (PHAL_DMA_priv_isChannelEnabled(handle->channel)) {
         return false;
     }
 
@@ -142,7 +121,7 @@ bool PHAL_DMA_setMemAddress(PHAL_DMA_Handle_t *handle, uint32_t address) {
 }
 
 bool PHAL_DMA_setLength(PHAL_DMA_Handle_t *handle, uint16_t length) {
-    if (handle == nullptr || handle->channel == nullptr || PHAL_DMA_priv_isChannelEnabled(handle->channel)) {
+    if (PHAL_DMA_priv_isChannelEnabled(handle->channel)) {
         return false;
     }
 
@@ -151,70 +130,41 @@ bool PHAL_DMA_setLength(PHAL_DMA_Handle_t *handle, uint16_t length) {
     return true;
 }
 
-uint16_t PHAL_DMA_getRemaining(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return 0;
-    }
-
-    return PHAL_DMA_priv_getRemainingLength(handle->channel);
-}
-
-bool PHAL_DMA_isBusy(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return false;
-    }
-
-    return PHAL_DMA_priv_isChannelEnabled(handle->channel);
-}
-
-bool PHAL_DMA_isComplete(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return false;
-    }
-
-    return PHAL_DMA_priv_readCompleteFlag(handle->wiring->periph, handle->wiring->channel_idx);
-}
-
-bool PHAL_DMA_isError(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return false;
-    }
-
-    return PHAL_DMA_priv_readErrorFlag(handle->wiring->periph, handle->wiring->channel_idx);
-}
-
-bool PHAL_DMA_clearFlags(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return false;
-    }
-
-    PHAL_DMA_priv_clearFlags(handle->wiring->periph, handle->wiring->channel_idx);
-    return true;
-}
-
-DMA_TypeDef *PHAL_DMA_getPeriph(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return nullptr;
-    }
-
-    return handle->wiring->periph;
-}
-
-uint8_t PHAL_DMA_getChannelIdx(PHAL_DMA_Handle_t *handle) {
-    if (handle == nullptr || handle->channel == nullptr) {
-        return 0;
-    }
-
-    return handle->wiring->channel_idx;
-}
-
 void PHAL_DMA_setMemInc(PHAL_DMA_Handle_t *handle, bool mem_inc) {
-    if (handle == nullptr || handle->channel == nullptr || PHAL_DMA_priv_isChannelEnabled(handle->channel)) {
+    if (PHAL_DMA_priv_isChannelEnabled(handle->channel)) {
         return;
     }
 
     handle->params.mem_inc = mem_inc;
     PHAL_DMA_priv_configChannel(handle->channel, handle->wiring, &handle->params);
+}
+
+uint16_t PHAL_DMA_getRemaining(PHAL_DMA_Handle_t *handle) {
+    return PHAL_DMA_priv_getRemainingLength(handle->channel);
+}
+
+bool PHAL_DMA_isBusy(PHAL_DMA_Handle_t *handle) {
+    return PHAL_DMA_priv_isChannelEnabled(handle->channel);
+}
+
+bool PHAL_DMA_isComplete(PHAL_DMA_Handle_t *handle) {
+    return PHAL_DMA_priv_readCompleteFlag(handle->wiring->periph, handle->wiring->channel_idx);
+}
+
+bool PHAL_DMA_isError(PHAL_DMA_Handle_t *handle) {
+    return PHAL_DMA_priv_readErrorFlag(handle->wiring->periph, handle->wiring->channel_idx);
+}
+
+void PHAL_DMA_clearFlags(PHAL_DMA_Handle_t *handle) {
+    PHAL_DMA_priv_clearFlags(handle->wiring->periph, handle->wiring->channel_idx);
+}
+
+DMA_TypeDef *PHAL_DMA_getPeriph(PHAL_DMA_Handle_t *handle) {
+    return handle->wiring->periph;
+}
+
+uint8_t PHAL_DMA_getChannelIdx(PHAL_DMA_Handle_t *handle) {
+    return handle->wiring->channel_idx;
 }
 
 

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -74,7 +74,7 @@ bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle) {
 }
 
 bool PHAL_DMA_initWithCallback(PHAL_DMA_Handle_t *handle, PHAL_DMA_IRQCallbackFn_t irq_fn, void *ctx) {
-    if (handle == nullptr) {
+    if (handle == nullptr || irq_fn == nullptr) {
         return false;
     }
     handle->callback.irq_fn = irq_fn;

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -65,7 +65,9 @@ bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle) {
 
     // If the user registered a callback, arm the NVIC line for this channel
     if (handle->callback.irq_fn != nullptr) {
-        NVIC_EnableIRQ(PHAL_DMA_priv_getIRQn(wiring->periph, wiring->channel_idx));
+        IRQn_Type irq = PHAL_DMA_priv_getIRQn(wiring->periph, wiring->channel_idx);
+        NVIC_ClearPendingIRQ(irq);
+        NVIC_EnableIRQ(irq);
     }
 
     return true;

--- a/firmware/common/phal_G4/dma/dma.c
+++ b/firmware/common/phal_G4/dma/dma.c
@@ -9,17 +9,17 @@
 
 #include "common/phal_G4/dma/dma_priv.h"
 
-// Tracks which (periph, channel_idx) pairs are currently claimed by a live handle,
-// so two handles can never conflict fight over the same channel.
+// Tracks which (periph, channel_idx) pairs are owned by a live handle.
+// Doubles as (a) conflict prevention when claiming a channel and (b) the
+// DMA PHAL's dispatch table for its own IRQ vectors below — this is what
+// lets DMA own every DMAx_ChannelN_IRQHandler while other HALs just
+// register a callback instead of defining competing vectors.
 // Index 0 is unused (channel numbering is 1-8).
+static PHAL_DMA_Handle_t *g_dma1_channel_owner[9];
+static PHAL_DMA_Handle_t *g_dma2_channel_owner[9];
 
-static bool g_dma1_channel_claimed[9];
-static bool g_dma2_channel_claimed[9];
-
-
-
-static bool *dma_channel_claim_slot(DMA_TypeDef *periph, uint8_t channel_idx) {
-    bool *table = (periph == DMA1) ? g_dma1_channel_claimed : g_dma2_channel_claimed;
+static PHAL_DMA_Handle_t **dma_channel_owner_slot(DMA_TypeDef *periph, uint8_t channel_idx) {
+    PHAL_DMA_Handle_t **table = (periph == DMA1) ? g_dma1_channel_owner : g_dma2_channel_owner;
     return &table[channel_idx];
 }
 
@@ -39,8 +39,8 @@ bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle) {
     }
 
     const PHAL_DMA_Wiring_t *wiring = handle->wiring;
-    bool *claimed = dma_channel_claim_slot(wiring->periph, wiring->channel_idx);
-    if (*claimed) {
+    PHAL_DMA_Handle_t **owner = dma_channel_owner_slot(wiring->periph, wiring->channel_idx);
+    if (*owner != nullptr) {
         // Already claimed by another handle
         return false;
     }
@@ -61,8 +61,18 @@ bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle) {
         PHAL_DMA_priv_configMux(wiring);
     }
 
-    *claimed = true;
+    *owner = handle;
+
     return true;
+}
+
+bool PHAL_DMA_initWithCallback(PHAL_DMA_Handle_t *handle, PHAL_DMA_IRQCallbackFn_t irq_fn, void *ctx) {
+    if (handle == nullptr) {
+        return false;
+    }
+    handle->callback.irq_fn = irq_fn;
+    handle->callback.ctx    = ctx;
+    return PHAL_DMA_init(handle);
 }
 
 bool PHAL_DMA_deinit(PHAL_DMA_Handle_t *handle) {
@@ -71,8 +81,14 @@ bool PHAL_DMA_deinit(PHAL_DMA_Handle_t *handle) {
     }
 
     PHAL_DMA_priv_disableChannel(handle->channel);
-    *dma_channel_claim_slot(handle->wiring->periph, handle->wiring->channel_idx) = false;
+
+
+    *dma_channel_owner_slot(handle->wiring->periph, handle->wiring->channel_idx) = nullptr;
+    
     handle->channel = nullptr;
+    handle->callback.irq_fn = nullptr;
+    handle->callback.ctx = nullptr;
+    
     return true;
 }
 

--- a/firmware/common/phal_G4/dma/dma.h
+++ b/firmware/common/phal_G4/dma/dma.h
@@ -41,6 +41,26 @@ typedef struct {
     bool tx_isr_en;            /*!< Enable transfer-complete and transfer-error interrupts */
 } PHAL_DMA_Params_t;
 
+
+/**
+ * Invoked from the DMA PHAL's own ISR when this handle's channel fires.
+ * Runs in interrupt context. ctx is whatever was passed to PHAL_DMA_registerCallback.
+ * ctx must remain valid for as long as the channel could still raise an interrupt naming this handle
+ */
+typedef void (*PHAL_DMA_IRQCallbackFn_t)(void *ctx);
+
+/**
+ * @brief Optional callback for DMA interrupts
+ *
+ * If the user wants to handle DMA interrupts, they can register a callback function and context pointer.
+ * The callback will be invoked from the DMA PHAL's own ISR when this handle's channel fires.
+ * The context pointer must remain valid for as long as the channel could still raise an interrupt naming this handle.
+ */
+typedef struct {
+    PHAL_DMA_IRQCallbackFn_t irq_fn;
+    void *ctx;
+} PHAL_DMA_Callback_t;
+
 /**
  * @brief A configured DMA transfer: fixed wiring + chosen parameters
  *
@@ -50,8 +70,20 @@ typedef struct {
     const PHAL_DMA_Wiring_t *wiring;
     PHAL_DMA_Params_t params;
     DMA_Channel_TypeDef *channel; /**< Populated by PHAL_DMA_init()!! */
+    PHAL_DMA_Callback_t callback; /**< Optional callback for DMA interupts.
+                                       Populated by PHAL_DMA_registerCallback() */
 } PHAL_DMA_Handle_t;
 
+
+/**
+ * @brief Register a callback for this handle's channel interrupt.
+ *
+ * Call before PHAL_DMA_init. The DMA PHAL owns every DMAx_ChannelN_IRQHandler
+ * vector; this is how another HAL gets notified instead of defining (and
+ * fighting over) that vector itself. PHAL_DMA_init also arms the NVIC line
+ * for this channel automatically once a callback is registered.
+ */
+bool PHAL_DMA_initWithCallback(PHAL_DMA_Handle_t *handle, PHAL_DMA_IRQCallbackFn_t irq_fn, void *ctx);
 
 /**
  * @brief Claim a DMA channel and configure it from handle->wiring and handle->params

--- a/firmware/common/phal_G4/dma/dma.h
+++ b/firmware/common/phal_G4/dma/dma.h
@@ -97,14 +97,6 @@ typedef struct {
 bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle);
 
 /**
- * @brief Register a callback for this handle's channel interrupt.
- *
- * Call before PHAL_DMA_init. The DMA PHAL owns every DMAx_ChannelN_IRQHandler
- * vector; this is how another HAL gets notified instead of defining (and
- * fighting over) that vector itself. PHAL_DMA_init also arms the NVIC line
- * for this channel automatically once a callback is registered.
- */
-/**
  * @brief Setup DMA callback then call PHAL_DMA_init()
  *
  * Additional behavior:

--- a/firmware/common/phal_G4/dma/dma.h
+++ b/firmware/common/phal_G4/dma/dma.h
@@ -119,26 +119,22 @@ bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle);
 bool PHAL_DMA_initWithCallback(PHAL_DMA_Handle_t *handle, PHAL_DMA_IRQCallbackFn_t irq_fn, void *ctx);
 
 /**
- * @brief Disable the channel and release its claim so another handle can
- * use the periph/channel_idx afterward
- * @return true on success, false if handle was never successfully init-ed
+ * @brief Disable the channel and release its claim/handle so another handle can
+ * use the periph/channel_idx afterward. Also disables the NVIC line if a callback was registered.
  */
-bool PHAL_DMA_deinit(PHAL_DMA_Handle_t *handle);
+void PHAL_DMA_deinit(PHAL_DMA_Handle_t *handle);
 
 /**
  * @brief Enable the channel, starting the transfer configured by PHAL_DMA_init()
- * @return true on success, false if handle was never successfully init-ed
  */
-bool PHAL_DMA_start(PHAL_DMA_Handle_t *handle);
+void PHAL_DMA_start(PHAL_DMA_Handle_t *handle);
 
 /**
  * @brief Disable the channel, stopping the transfer immediately
  * 
  * Whatever hasn't transferred yet is left un-transferred
- * 
- * @return true on success, false if handle was never successfully init-ed
  */
-bool PHAL_DMA_stop(PHAL_DMA_Handle_t *handle);
+void PHAL_DMA_stop(PHAL_DMA_Handle_t *handle);
 
 /**
  * @brief Reload the transfer count from handle->params.tx_size and start again
@@ -148,25 +144,32 @@ bool PHAL_DMA_stop(PHAL_DMA_Handle_t *handle);
  *
  * @return true on success, false if handle was never successfully init-ed
  */
-bool PHAL_DMA_restart(PHAL_DMA_Handle_t *handle);
+void PHAL_DMA_restart(PHAL_DMA_Handle_t *handle);
 
 /**
  * @brief Change the memory address for the next transfer
- * @return true on success, false if handle was never successfully
- * init-ed or the channel is currently enabled
+ * @return true on success, false if the channel is currently enabled
  */
 bool PHAL_DMA_setMemAddress(PHAL_DMA_Handle_t *handle, uint32_t address);
 
 /**
  * @brief Change the transfer length (element count) for the next transfer
- * @return true on success, false if handle was never successfully
- * init-ed, or the channel is currently enabled
+ * @return true on success, false if the channel is currently enabled
  */
 bool PHAL_DMA_setLength(PHAL_DMA_Handle_t *handle, uint16_t length);
 
 /**
+ * @brief Set whether the memory address increments after each transfer and rebuild the channel configuration
+ *
+ * If the channel is currently enabled, this function will not change the configuration
+ * 
+ * @param mem_inc true to increment memory address after each transfer, false to keep it constant
+ */
+void PHAL_DMA_setMemInc(PHAL_DMA_Handle_t *handle, bool mem_inc);
+
+/**
  * @brief Number of elements still left to transfer on this channel
- * @return elements outstanding, or 0 if handle was never successfully init-ed
+ * @return Elements outstanding
  */
 uint16_t PHAL_DMA_getRemaining(PHAL_DMA_Handle_t *handle);
 
@@ -174,8 +177,7 @@ uint16_t PHAL_DMA_getRemaining(PHAL_DMA_Handle_t *handle);
  * @brief Check whether the channel is currently enabled (transfer in
  * progress, or in circular mode, running continuously)
  *
- * @return true if the channel is enabled, false if disabled or handle
- * was never successfully init-ed
+ * @return true if the channel is enabled, false if disabled
  */
 bool PHAL_DMA_isBusy(PHAL_DMA_Handle_t *handle);
 
@@ -206,32 +208,22 @@ bool PHAL_DMA_isError(PHAL_DMA_Handle_t *handle);
  * channel, so a finished transfer can be reused
  *
  * @param handle initialized DMA handle
- * @return true on success, false if handle was never successfully initialized
  */
-bool PHAL_DMA_clearFlags(PHAL_DMA_Handle_t *handle);
+void PHAL_DMA_clearFlags(PHAL_DMA_Handle_t *handle);
 
 /**
  * @brief Get the DMA peripheral (DMA1 or DMA2) for a given handle
  * 
- * @return Return nullptr if handle is null otherwise return the DMA peripheral for the given handle
+ * @return the DMA peripheral for the given handle
  */
 DMA_TypeDef *PHAL_DMA_getPeriph(PHAL_DMA_Handle_t *handle);
 
 /**
  * @brief Get the channel number (1-8) for a given handle
  * 
- * @return uint8_t Return 0 if handle is null otherwise return the channel number for the given handle
+ * @return the channel number for the given handle
  */
 uint8_t PHAL_DMA_getChannelIdx(PHAL_DMA_Handle_t *handle);
-
-/**
- * @brief Set whether the memory address increments after each transfer and rebuild the channel configuration
- *
- * If the channel is currently enabled, this function will not change the configuration
- * 
- * @param mem_inc true to increment memory address after each transfer, false to keep it constant
- */
-void PHAL_DMA_setMemInc(PHAL_DMA_Handle_t *handle, bool mem_inc);
 
 
 #endif // PHAL_G4_DMA_H

--- a/firmware/common/phal_G4/dma/dma.h
+++ b/firmware/common/phal_G4/dma/dma.h
@@ -43,37 +43,58 @@ typedef struct {
 
 
 /**
- * Invoked from the DMA PHAL's own ISR when this handle's channel fires.
- * Runs in interrupt context. ctx is whatever was passed to PHAL_DMA_registerCallback.
- * ctx must remain valid for as long as the channel could still raise an interrupt naming this handle
+ * @brief Signature for a DMA channel interrupt callback
+ *
+ * Invoked from the DMA PHAL's own ISR when the channel bound to this callback fires.
+ * Runs in interrupt context.
+ *
+ * @param ctx Opaque pointer supplied to PHAL_DMA_initWithCallback(), passed
+ *            back unexamined. Must remain valid for as long as the channel
+ *            could still raise an interrupt referencing it.
  */
 typedef void (*PHAL_DMA_IRQCallbackFn_t)(void *ctx);
 
 /**
- * @brief Optional callback for DMA interrupts
+ * @brief A DMA channel interrupt callback and the context passed to it
  *
- * If the user wants to handle DMA interrupts, they can register a callback function and context pointer.
- * The callback will be invoked from the DMA PHAL's own ISR when this handle's channel fires.
- * The context pointer must remain valid for as long as the channel could still raise an interrupt naming this handle.
+ * Set via PHAL_DMA_initWithCallback().
+ * Leave zero-initialized (irq_fn == nullptr) for channels that don't need interrupt-driven
+ * completion (ex: a channel whose completion is polled or driven by another peripheral's
+ * IDLE/status interrupt instead).
  */
 typedef struct {
-    PHAL_DMA_IRQCallbackFn_t irq_fn;
-    void *ctx;
+    PHAL_DMA_IRQCallbackFn_t irq_fn; /**< nullptr if this channel has no registered callback */
+    void *ctx;                       /**< Passed to irq_fn as-is. See PHAL_DMA_IRQCallbackFn_t
+                                          for its lifetime requirement */
 } PHAL_DMA_Callback_t;
 
 /**
  * @brief A configured DMA transfer: fixed wiring + chosen parameters
  *
- * channel is populated by PHAL_DMA_init(), do not specify when constructing PHAL_DMA_Handle_t.
+ * channel and callback are populated by PHAL_DMA_init()/PHAL_DMA_initWithCallback(),
+ * do not directly set either when constructing a PHAL_DMA_Handle_t.
  */
 typedef struct {
     const PHAL_DMA_Wiring_t *wiring;
     PHAL_DMA_Params_t params;
-    DMA_Channel_TypeDef *channel; /**< Populated by PHAL_DMA_init()!! */
-    PHAL_DMA_Callback_t callback; /**< Optional callback for DMA interupts.
-                                       Populated by PHAL_DMA_registerCallback() */
+    DMA_Channel_TypeDef *channel; /**< Populated by PHAL_DMA_init[WithCallback]() */
+    PHAL_DMA_Callback_t callback; /**< Populated by PHAL_DMA_initWithCallback() */
 } PHAL_DMA_Handle_t;
 
+
+/**
+ * @brief Claim a DMA channel and configure it from handle->wiring and handle->params
+ *
+ * Does not start the transfer (call PHAL_DMA_start() afterward).
+ * 
+ * Does not register an interrupt callback, handle->callback is left untouched (and should be zeroed).
+ *
+ * @param handle wiring + params to configure. handle->channel is populated on success
+ * @return true on success; false if handle/wiring invalid (NULL, channel_idx
+ *         is outside 1-8, periph isn't DMA1/DMA2, or that periph/channel_idx
+ *         is already claimed by another live handle)
+ */
+bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle);
 
 /**
  * @brief Register a callback for this handle's channel interrupt.
@@ -83,19 +104,19 @@ typedef struct {
  * fighting over) that vector itself. PHAL_DMA_init also arms the NVIC line
  * for this channel automatically once a callback is registered.
  */
-bool PHAL_DMA_initWithCallback(PHAL_DMA_Handle_t *handle, PHAL_DMA_IRQCallbackFn_t irq_fn, void *ctx);
-
 /**
- * @brief Claim a DMA channel and configure it from handle->wiring and handle->params
- 
- * Does not start the transfer (call PHAL_DMA_start() afterward).
+ * @brief Setup DMA callback then call PHAL_DMA_init()
  *
- * @param handle wiring + params to configure. handle->channel is populated in on success
- * @return true on success; false if handle/wiring invalid (NULL, channel_idx
- * is outside 1-8, periph isn't DMA1/DMA2, or that periph/channel_idx
- * is already claimed by another live handle)
+ * Additional behavior:
+ * On success, handle->callback is set and this channel's NVIC line is enabled
+ *
+ * @param handle wiring + params to configure. handle->channel and handle->callback are
+ *               populated on success
+ * @param irq_fn callback to invoke when this channel's interrupt fires; must not be nullptr
+ * @param ctx opaque pointer passed to irq_fn unexamined. See PHAL_DMA_IRQCallbackFn_t for its lifetime requirement
+ * @return true on success; false under the same conditions as PHAL_DMA_init(), or if irq_fn is nullptr
  */
-bool PHAL_DMA_init(PHAL_DMA_Handle_t *handle);
+bool PHAL_DMA_initWithCallback(PHAL_DMA_Handle_t *handle, PHAL_DMA_IRQCallbackFn_t irq_fn, void *ctx);
 
 /**
  * @brief Disable the channel and release its claim so another handle can

--- a/firmware/common/phal_G4/dma/dma.h
+++ b/firmware/common/phal_G4/dma/dma.h
@@ -141,8 +141,6 @@ void PHAL_DMA_stop(PHAL_DMA_Handle_t *handle);
  * 
  * Safe to call regardless of whether the channel state (enabled, mid-transfer, or stopped on an error),
  * it always disables first.
- *
- * @return true on success, false if handle was never successfully init-ed
  */
 void PHAL_DMA_restart(PHAL_DMA_Handle_t *handle);
 

--- a/firmware/common/phal_G4/dma/dma_priv.c
+++ b/firmware/common/phal_G4/dma/dma_priv.c
@@ -29,6 +29,11 @@ DMA_Channel_TypeDef *PHAL_DMA_priv_getChannel(DMA_TypeDef *periph, uint8_t chann
     return (DMA_Channel_TypeDef *)((uint8_t *)base + PHAL_DMA_PRIV_DMA_CHANNEL_MEM_STRIDE * (channel_idx - 1U));
 }
 
+IRQn_Type PHAL_DMA_priv_getIRQn(DMA_TypeDef *periph, uint8_t channel_idx) {
+    IRQn_Type base = (periph == DMA1) ? DMA1_Channel1_IRQn : DMA2_Channel1_IRQn;
+    return (IRQn_Type)(base + channel_idx - 1);
+}
+
 void PHAL_DMA_priv_disableChannel(DMA_Channel_TypeDef *channel) {
     // CCR = Channel Configuration Register
     // EN = channel Enable bit

--- a/firmware/common/phal_G4/dma/dma_priv.h
+++ b/firmware/common/phal_G4/dma/dma_priv.h
@@ -21,6 +21,9 @@ void PHAL_DMA_priv_enableClock(DMA_TypeDef *periph);
 /// Look up the channel instance for (periph, channel_idx). channel_idx must be 1-8
 DMA_Channel_TypeDef *PHAL_DMA_priv_getChannel(DMA_TypeDef *periph, uint8_t channel_idx);
 
+// Get the NVIC IRQn for (periph, channel_idx). channel_idx must be 1-8
+IRQn_Type PHAL_DMA_priv_getIRQn(DMA_TypeDef *periph, uint8_t channel_idx);
+
 /// Disable a channel and block until hardware confirms it is off
 void PHAL_DMA_priv_disableChannel(DMA_Channel_TypeDef *channel);
 

--- a/firmware/common/phal_G4/spi/spi.c
+++ b/firmware/common/phal_G4/spi/spi.c
@@ -21,26 +21,8 @@ void PHAL_SPI_txCallback(SPI_InitConfig_t *spi) {
     (void)spi;
 }
 
-/* Map DMA channel IRQs to handler for common SPI usage. Adjust as needed per project. */
-[[gnu::weak]]
-void DMA1_Channel3_IRQHandler(void) { // example: SPI1_TX on DMA1 Ch3
-    PHAL_SPI_priv_handleTxComplete(DMA1, 3);
-}
-
-[[gnu::weak]]
-void DMA1_Channel5_IRQHandler(void) { // example: SPI2_TX on DMA1 Ch5
-    PHAL_SPI_priv_handleTxComplete(DMA1, 5);
-}
-
-/// Service SPI3 TX when it owns DMA2 channel 3.
-void PHAL_SPI_DMA2_Channel3_IRQHandler(void) {
-    PHAL_SPI_priv_handleTxComplete(DMA2, 3);
-}
-
-// ADC4 provides the strong shared vector when it owns DMA2 channel 3.
-[[gnu::weak]]
-void DMA2_Channel3_IRQHandler(void) {
-    PHAL_SPI_DMA2_Channel3_IRQHandler();
+static void spi_tx_dma_callback(void *ctx) {
+    PHAL_SPI_priv_handleTxComplete((SPI_InitConfig_t *)ctx);
 }
 
 bool PHAL_SPI_init(SPI_InitConfig_t *cfg) {
@@ -57,13 +39,14 @@ bool PHAL_SPI_init(SPI_InitConfig_t *cfg) {
     PHAL_SPI_priv_configCR2(cfg);
 
     // DMA setup is required 
-    if (!PHAL_DMA_init(cfg->rx_dma) || !PHAL_DMA_init(cfg->tx_dma)) {
+    if (!PHAL_DMA_init(cfg->rx_dma) || !PHAL_DMA_initWithCallback(cfg->tx_dma, spi_tx_dma_callback, cfg)) {
         return false;
     }
 
     // Deassert CS in master when using software NSS
-    if (cfg->mode == SPI_MODE_MASTER && cfg->nss_sw)
+    if (cfg->mode == SPI_MODE_MASTER && cfg->nss_sw) {
         PHAL_writeGPIO(cfg->nss_gpio_port, cfg->nss_gpio_pin, 1);
+    }
 
     PHAL_SPI_priv_resetTransferState(cfg);
 
@@ -98,7 +81,7 @@ void PHAL_SPI_transfer(SPI_InitConfig_t *spi,
     }
     PHAL_DMA_setLength(spi->tx_dma, data_len);
 
-    // RX DMA  
+    // RX DMA
     PHAL_SPI_priv_enableDMA_RX(spi);
 
     if (!in_data) {
@@ -110,16 +93,6 @@ void PHAL_SPI_transfer(SPI_InitConfig_t *spi,
     }
     PHAL_DMA_setLength(spi->rx_dma, data_len);
     PHAL_DMA_restart(spi->rx_dma);
-
-    PHAL_SPI_priv_registerActiveTx(spi);
-
-    if (PHAL_DMA_getPeriph(spi->tx_dma) == DMA1) {
-        NVIC_EnableIRQ(DMA1_Channel1_IRQn + (PHAL_DMA_getChannelIdx(spi->tx_dma) - 1));
-    } else if (PHAL_DMA_getPeriph(spi->tx_dma) == DMA2) {
-        NVIC_EnableIRQ(DMA2_Channel1_IRQn + (PHAL_DMA_getChannelIdx(spi->tx_dma) - 1));
-    } else {
-        __builtin_trap();
-    }
 
     // Start SPI and kick TX DMA
     PHAL_SPI_priv_Enable(spi);
@@ -135,7 +108,7 @@ void PHAL_SPI_transferBlocking(SPI_InitConfig_t *spi,
     PHAL_SPI_transfer(spi, out_data, in_data, data_len);
     // Wait for this transfer to complete
     while (PHAL_SPI_busy(spi)) {
-        __asm__("nop");
+        __NOP();
     }
 }
 

--- a/firmware/common/phal_G4/spi/spi.c
+++ b/firmware/common/phal_G4/spi/spi.c
@@ -72,27 +72,29 @@ void PHAL_SPI_transfer(SPI_InitConfig_t *spi,
     spi->_busy = true;
 
     // TX DMA enable
+    PHAL_DMA_stop(spi->tx_dma);
     PHAL_SPI_priv_enableDMA_TX(spi);
     if (!out_data) {
         PHAL_DMA_setMemInc(spi->tx_dma, false);
-        PHAL_DMA_setMemAddress(spi->tx_dma, (uint32_t)&zero);
+        (void)PHAL_DMA_setMemAddress(spi->tx_dma, (uint32_t)&zero);
     } else {
         PHAL_DMA_setMemInc(spi->tx_dma, true);
-        PHAL_DMA_setMemAddress(spi->tx_dma, (uint32_t)out_data);
+        (void)PHAL_DMA_setMemAddress(spi->tx_dma, (uint32_t)out_data);
     }
-    PHAL_DMA_setLength(spi->tx_dma, data_len);
+    (void)PHAL_DMA_setLength(spi->tx_dma, data_len);
 
     // RX DMA
+    PHAL_DMA_stop(spi->rx_dma);
     PHAL_SPI_priv_enableDMA_RX(spi);
 
     if (!in_data) {
         PHAL_DMA_setMemInc(spi->rx_dma, false);
-        PHAL_DMA_setMemAddress(spi->rx_dma, (uint32_t)&trash_can);
+        (void)PHAL_DMA_setMemAddress(spi->rx_dma, (uint32_t)&trash_can);
     } else {
         PHAL_DMA_setMemInc(spi->rx_dma, true);
-        PHAL_DMA_setMemAddress(spi->rx_dma, (uint32_t)in_data);
+        (void)PHAL_DMA_setMemAddress(spi->rx_dma, (uint32_t)in_data);
     }
-    PHAL_DMA_setLength(spi->rx_dma, data_len);
+    (void)PHAL_DMA_setLength(spi->rx_dma, data_len);
     PHAL_DMA_restart(spi->rx_dma);
 
     // Start SPI and kick TX DMA

--- a/firmware/common/phal_G4/spi/spi.c
+++ b/firmware/common/phal_G4/spi/spi.c
@@ -21,6 +21,7 @@ void PHAL_SPI_txCallback(SPI_InitConfig_t *spi) {
     (void)spi;
 }
 
+// DMA callback handler for TX completion
 static void spi_tx_dma_callback(void *ctx) {
     PHAL_SPI_priv_handleTxComplete((SPI_InitConfig_t *)ctx);
 }

--- a/firmware/common/phal_G4/spi/spi_priv.c
+++ b/firmware/common/phal_G4/spi/spi_priv.c
@@ -11,8 +11,6 @@
 #include "common/phal_G4/rcc/rcc.h"
 #include "common/utils/clamp.h"
 
-static volatile SPI_InitConfig_t *g_dma1_active_tx[8] = {0};
-static volatile SPI_InitConfig_t *g_dma2_active_tx[8] = {0};
 
 static inline uint32_t LOG2_DOWN(uint32_t x) {
     return 31U - (uint32_t)__builtin_clz(x);
@@ -50,10 +48,12 @@ void PHAL_SPI_priv_configCR1(SPI_InitConfig_t *cfg, uint32_t f_div) {
         // BR ignored in slave
     }
     cfg->periph->CR1 &= ~(SPI_CR1_CPOL | SPI_CR1_CPHA);
-    if (cfg->cpol)
+    if (cfg->cpol) {
         cfg->periph->CR1 |= SPI_CR1_CPOL;
-    if (cfg->cpha)
+    }
+    if (cfg->cpha) {
         cfg->periph->CR1 |= SPI_CR1_CPHA;
+    }
 }
 
 uint32_t PHAL_SPI_priv_calcBaudRatePrescaler(uint32_t data_rate, SPI_TypeDef *periph) {
@@ -61,10 +61,11 @@ uint32_t PHAL_SPI_priv_calcBaudRatePrescaler(uint32_t data_rate, SPI_TypeDef *pe
     // BR prescaler in CR1 takes values 0b000 to 0b111, which correspond to divisors of 2, 4, 8, 16, 32, 64, 128, and 256.
     // This function calculates the BR value for a given data rate and SPI peripheral.
     uint32_t f_div;
-    if ((uint32_t)periph == SPI1_BASE)
+    if ((uint32_t)periph == SPI1_BASE) {
         f_div = LOG2_DOWN(PHAL_RCC_getAPB2ClockHz() / data_rate) - 1;
-    else
+    } else {
         f_div = LOG2_DOWN(PHAL_RCC_getAPB1ClockHz() / data_rate) - 1;
+    }
     f_div = CLAMP(f_div, 0, 0b111);
     return f_div;
 } 
@@ -86,25 +87,27 @@ void PHAL_SPI_priv_enableDMA_RX(SPI_InitConfig_t *cfg) {
     cfg->periph->CR2 |= SPI_CR2_RXDMAEN;
 }
 
-void PHAL_SPI_priv_handleTxComplete(DMA_TypeDef *dma_periph, uint8_t channel) {
-    if (channel < 1 || channel > 8) return;
-    volatile SPI_InitConfig_t **active_table =
-        (dma_periph == DMA1) ? g_dma1_active_tx : g_dma2_active_tx;
-    
-    SPI_InitConfig_t *transfer = (SPI_InitConfig_t *)active_table[channel - 1];
-
-    if (transfer == NULL) {
-        dma_periph->IFCR = DMA_GIF_MASK(channel); // clear unhandled interrupt flags
+void PHAL_SPI_priv_handleTxComplete(SPI_InitConfig_t *transfer) {
+    if (transfer == NULL || transfer->tx_dma == NULL) {
         return;
     }
+
+    DMA_TypeDef *dma_periph = transfer->tx_dma->wiring->periph;
+    uint8_t channel         = transfer->tx_dma->wiring->channel_idx;
+
+    if (channel < 1 || channel > 8) {
+        return;
+    }
+    
     if (dma_periph->ISR & DMA_TEIF_MASK(channel)) {
         dma_periph->IFCR |= DMA_TEIF_MASK(channel);
         transfer->_error = true;
     }
+
     if (dma_periph->ISR & DMA_TCIF_MASK(channel)) {
         // Wait for TXE and not busy
         while (!(transfer->periph->SR & SPI_SR_TXE) || (transfer->periph->SR & SPI_SR_BSY)) {
-            __asm__("nop");
+            __NOP();
         }
         // If RX DMA is used, wait until its TC flag also asserts before teardown
         if (transfer->rx_dma) {
@@ -113,7 +116,7 @@ void PHAL_SPI_priv_handleTxComplete(DMA_TypeDef *dma_periph, uint8_t channel) {
             uint32_t rx_tc_mask = DMA_FLAG_MASK(DMA_ISR_TCIF1, rx_ch);
             // Busy-wait for RX complete
             while (!(rx_dma->ISR & rx_tc_mask)) {
-                __asm__("nop");
+                __NOP();
             }
             // Clear RX flags and stop RX
             rx_dma->IFCR |= rx_tc_mask;
@@ -121,11 +124,13 @@ void PHAL_SPI_priv_handleTxComplete(DMA_TypeDef *dma_periph, uint8_t channel) {
         }
 
         // Deassert CS after both TX and RX complete
-        if (transfer->nss_sw)
+        if (transfer->nss_sw) {
             PHAL_writeGPIO(transfer->nss_gpio_port, transfer->nss_gpio_pin, 1);
+        }
 
-        if (transfer->tx_dma)
+        if (transfer->tx_dma) {
             PHAL_DMA_stop(transfer->tx_dma);
+        }
 
         transfer->periph->CR1 &= ~SPI_CR1_SPE;
         transfer->periph->CR2 &= ~(SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
@@ -134,7 +139,6 @@ void PHAL_SPI_priv_handleTxComplete(DMA_TypeDef *dma_periph, uint8_t channel) {
 
         dma_periph->IFCR |= DMA_TCIF_MASK(channel);
         dma_periph->IFCR |= DMA_GIF_MASK(channel);
-        active_table[channel - 1] = NULL;
 
         PHAL_SPI_txCallback(transfer);
     }
@@ -151,19 +155,6 @@ void PHAL_SPI_priv_resetTransferState(SPI_InitConfig_t *cfg) {
     cfg->_fifo_overrun      = false;
 }
 
-
-void PHAL_SPI_priv_registerActiveTx(SPI_InitConfig_t *spi) {
-    if (!spi || !spi->tx_dma) return;
-
-    uint8_t ch = spi->tx_dma->wiring->channel_idx;
-    if (ch < 1 || ch > 8) return;
-
-    if (spi->tx_dma->wiring->periph == DMA1) {
-        g_dma1_active_tx[ch - 1] = spi; 
-    } else if (spi->tx_dma->wiring->periph == DMA2) {
-        g_dma2_active_tx[ch - 1] = spi;
-    }
-}
 
 void PHAL_SPI_priv_Enable(SPI_InitConfig_t *spi) {
     spi->periph->CR1 |= SPI_CR1_SPE;

--- a/firmware/common/phal_G4/spi/spi_priv.c
+++ b/firmware/common/phal_G4/spi/spi_priv.c
@@ -92,34 +92,23 @@ void PHAL_SPI_priv_handleTxComplete(SPI_InitConfig_t *transfer) {
         return;
     }
 
-    DMA_TypeDef *dma_periph = transfer->tx_dma->wiring->periph;
-    uint8_t channel         = transfer->tx_dma->wiring->channel_idx;
-
-    if (channel < 1 || channel > 8) {
-        return;
-    }
-    
-    if (dma_periph->ISR & DMA_TEIF_MASK(channel)) {
-        dma_periph->IFCR |= DMA_TEIF_MASK(channel);
+    if (PHAL_DMA_isError(transfer->tx_dma)) {
         transfer->_error = true;
     }
 
-    if (dma_periph->ISR & DMA_TCIF_MASK(channel)) {
+    if (PHAL_DMA_isComplete(transfer->tx_dma)) {
         // Wait for TXE and not busy
         while (!(transfer->periph->SR & SPI_SR_TXE) || (transfer->periph->SR & SPI_SR_BSY)) {
             __NOP();
         }
         // If RX DMA is used, wait until its TC flag also asserts before teardown
         if (transfer->rx_dma) {
-            DMA_TypeDef *rx_dma = transfer->rx_dma->wiring->periph;
-            uint8_t rx_ch       = transfer->rx_dma->wiring->channel_idx;
-            uint32_t rx_tc_mask = DMA_FLAG_MASK(DMA_ISR_TCIF1, rx_ch);
             // Busy-wait for RX complete
-            while (!(rx_dma->ISR & rx_tc_mask)) {
+            while (!PHAL_DMA_isComplete(transfer->rx_dma)) {
                 __NOP();
             }
             // Clear RX flags and stop RX
-            rx_dma->IFCR |= rx_tc_mask;
+            PHAL_DMA_clearFlags(transfer->rx_dma);
             PHAL_DMA_stop(transfer->rx_dma);
         }
 
@@ -137,15 +126,10 @@ void PHAL_SPI_priv_handleTxComplete(SPI_InitConfig_t *transfer) {
 
         PHAL_SPI_priv_resetTransferState(transfer);
 
-        dma_periph->IFCR |= DMA_TCIF_MASK(channel);
-        dma_periph->IFCR |= DMA_GIF_MASK(channel);
-
         PHAL_SPI_txCallback(transfer);
     }
 
-    if (dma_periph->ISR & DMA_HTIF_MASK(channel)) {
-        dma_periph->IFCR |= DMA_HTIF_MASK(channel);
-    }
+    PHAL_DMA_clearFlags(transfer->tx_dma);
 }
 
 void PHAL_SPI_priv_resetTransferState(SPI_InitConfig_t *cfg) {

--- a/firmware/common/phal_G4/spi/spi_priv.h
+++ b/firmware/common/phal_G4/spi/spi_priv.h
@@ -13,73 +13,53 @@
 #include "common/phal_G4/gpio/gpio.h"
 
 
-/** @brief Compute the DMA flag mask for a channel. */
+/// Compute the DMA flag mask for a channel
 #define DMA_FLAG_MASK(flag_base, channel) (((uint32_t)(flag_base)) << (4 * ((uint32_t)(channel) - 1)))
 
-/** @brief DMA transfer-complete flag mask. */
+/// DMA transfer-complete flag mask
 #define DMA_TCIF_MASK(channel) DMA_FLAG_MASK(DMA_ISR_TCIF1, (channel))
 
-/** @brief DMA transfer-error flag mask. */
+/// DMA transfer-error flag mask
 #define DMA_TEIF_MASK(channel) DMA_FLAG_MASK(DMA_ISR_TEIF1, (channel))
 
-/** @brief DMA half-transfer flag mask. */
+/// DMA half-transfer flag mask
 #define DMA_HTIF_MASK(channel) DMA_FLAG_MASK(DMA_ISR_HTIF1, (channel))
 
-/** @brief DMA global interrupt flag mask. */
+/// DMA global interrupt flag mask
 #define DMA_GIF_MASK(channel)  DMA_FLAG_MASK(DMA_ISR_GIF1,  (channel))
 
-/**
- * @brief Enable the peripheral clock for an SPI instance.
- */
+
+/// Enable the peripheral clock for an SPI instance.
 void PHAL_SPI_priv_enableClock(SPI_TypeDef *periph);
 
-/**
- * @brief Configure the SPI CR1 register.
- */
+/// Configure the SPI CR1 register.
 void PHAL_SPI_priv_configCR1(SPI_InitConfig_t *cfg, uint32_t f_div);
 
-/**
- * @brief Calculate the SPI baud-rate prescaler.
- */
+/// Calculate the SPI baud-rate prescaler.
 uint32_t PHAL_SPI_priv_calcBaudRatePrescaler(uint32_t data_rate, SPI_TypeDef *periph);
 
-/**
- * @brief Configure the SPI CR2 register.
- */
+/// Configure the SPI CR2 register.
 void PHAL_SPI_priv_configCR2(SPI_InitConfig_t *cfg);
 
-/**
- * @brief Enable SPI transmit DMA requests.
- */
+/// Enable SPI transmit DMA requests.
 void PHAL_SPI_priv_enableDMA_TX(SPI_InitConfig_t *cfg);
 
-/**
- * @brief Enable SPI receive DMA requests.
- */
+/// Enable SPI receive DMA requests.
 void PHAL_SPI_priv_enableDMA_RX(SPI_InitConfig_t *cfg);
 
-/**
- * @brief Handle DMA transmit-complete interrupts.
- */
+/// Handle DMA transmit-complete interrupts.
 void PHAL_SPI_priv_handleTxComplete(SPI_InitConfig_t *transfer);
 
-/**
- * @brief Reset the internal SPI transfer state.
- */
+/// Reset the internal SPI transfer state.
 void PHAL_SPI_priv_resetTransferState(SPI_InitConfig_t *cfg);
 
-/**
- * @brief Register an active SPI transmit transfer.
- */
+/// Register an active SPI transmit transfer.
 void PHAL_SPI_priv_registerActiveTx(SPI_InitConfig_t *spi);
 
-/**
- * @brief Enable the SPI peripheral.
- */
+/// Enable the SPI peripheral.
 void PHAL_SPI_priv_Enable(SPI_InitConfig_t *spi);
 
-/**
- * @brief Disable the SPI peripheral.
- */
+/// Disable the SPI peripheral.
 void PHAL_SPI_priv_Disable(SPI_InitConfig_t *spi);
-#endif /* _PHAL_G4_SPI_PRIV_H */
+
+#endif // _PHAL_G4_SPI_PRIV_H

--- a/firmware/common/phal_G4/spi/spi_priv.h
+++ b/firmware/common/phal_G4/spi/spi_priv.h
@@ -13,22 +13,6 @@
 #include "common/phal_G4/gpio/gpio.h"
 
 
-/// Compute the DMA flag mask for a channel
-#define DMA_FLAG_MASK(flag_base, channel) (((uint32_t)(flag_base)) << (4 * ((uint32_t)(channel) - 1)))
-
-/// DMA transfer-complete flag mask
-#define DMA_TCIF_MASK(channel) DMA_FLAG_MASK(DMA_ISR_TCIF1, (channel))
-
-/// DMA transfer-error flag mask
-#define DMA_TEIF_MASK(channel) DMA_FLAG_MASK(DMA_ISR_TEIF1, (channel))
-
-/// DMA half-transfer flag mask
-#define DMA_HTIF_MASK(channel) DMA_FLAG_MASK(DMA_ISR_HTIF1, (channel))
-
-/// DMA global interrupt flag mask
-#define DMA_GIF_MASK(channel)  DMA_FLAG_MASK(DMA_ISR_GIF1,  (channel))
-
-
 /// Enable the peripheral clock for an SPI instance.
 void PHAL_SPI_priv_enableClock(SPI_TypeDef *periph);
 

--- a/firmware/common/phal_G4/spi/spi_priv.h
+++ b/firmware/common/phal_G4/spi/spi_priv.h
@@ -37,9 +37,6 @@ void PHAL_SPI_priv_handleTxComplete(SPI_InitConfig_t *transfer);
 /// Reset the internal SPI transfer state.
 void PHAL_SPI_priv_resetTransferState(SPI_InitConfig_t *cfg);
 
-/// Register an active SPI transmit transfer.
-void PHAL_SPI_priv_registerActiveTx(SPI_InitConfig_t *spi);
-
 /// Enable the SPI peripheral.
 void PHAL_SPI_priv_Enable(SPI_InitConfig_t *spi);
 

--- a/firmware/common/phal_G4/spi/spi_priv.h
+++ b/firmware/common/phal_G4/spi/spi_priv.h
@@ -61,7 +61,7 @@ void PHAL_SPI_priv_enableDMA_RX(SPI_InitConfig_t *cfg);
 /**
  * @brief Handle DMA transmit-complete interrupts.
  */
-void PHAL_SPI_priv_handleTxComplete(DMA_TypeDef *dma_periph, uint8_t channel);
+void PHAL_SPI_priv_handleTxComplete(SPI_InitConfig_t *transfer);
 
 /**
  * @brief Reset the internal SPI transfer state.

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -87,9 +87,9 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
  * @return true if every DMA reconfiguration step succeeded, false otherwise
  */
 bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, bool cont) {
-    USART_TypeDef *hw = PHAL_USART_priv_periph(periph_idx);
+    USART_TypeDef *periph = PHAL_USART_priv_periph(periph_idx);
 
-    PHAL_USART_priv_stopRx(hw);
+    PHAL_USART_priv_stopRx(periph);
 
     usart_state[periph_idx].cont_rx = cont;
     usart_state[periph_idx].rxfer_size = len;
@@ -100,7 +100,7 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, boo
     bool address_set = PHAL_DMA_setMemAddress(rx_dma, (uint32_t)data);
     bool length_set  = PHAL_DMA_setLength(rx_dma, len);
 
-    PHAL_USART_priv_flushRx(hw);
+    PHAL_USART_priv_flushRx(periph);
 
     bool restarted = PHAL_DMA_restart(rx_dma);
 
@@ -109,7 +109,7 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, boo
     }
 
     usart_state[periph_idx].rx_busy = true;
-    PHAL_USART_priv_startRx(hw);
+    PHAL_USART_priv_startRx(periph);
 
     return true;
 }
@@ -170,24 +170,24 @@ bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t 
     return true;
 }
 
-static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
-    USART_TypeDef *periph_idx = PHAL_USART_priv_periph(idx);
+static void usart_handle_irq(PHAL_USART_Idx_t periph_idx) {
+    USART_TypeDef *periph = PHAL_USART_priv_periph(periph_idx);
 
-    if (PHAL_USART_priv_txCompleteActive(periph_idx)) {
-        PHAL_USART_priv_finishTx(periph_idx);
-        usart_state[idx].tx_busy = false;
+    if (PHAL_USART_priv_txCompleteActive(periph)) {
+        PHAL_USART_priv_finishTx(periph);
+        usart_state[periph_idx].tx_busy = false;
     }
 
-    if (!PHAL_USART_priv_idleActive(periph_idx)) {
+    if (!PHAL_USART_priv_idleActive(periph)) {
         return;
     }
 
-    PHAL_USART_priv_clearIdle(periph_idx);
+    PHAL_USART_priv_clearIdle(periph);
 
-    PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
+    PHAL_DMA_Handle_t *rx_dma = &usart_state[periph_idx].rx_dma;
 
     // Enabling RE on an already-idle line can raise IDLE before the first byte reaches DMA
-    if (PHAL_DMA_getRemaining(rx_dma) == usart_state[idx].rxfer_size) {
+    if (PHAL_DMA_getRemaining(rx_dma) == usart_state[periph_idx].rxfer_size) {
         return;
     }
 
@@ -195,30 +195,30 @@ static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
 
     // CNDTR counts down, so the shortfall against the configured length is
     // what actually landed. Read it before the re-arm reloads the count.
-    uint16_t received = (uint16_t)(usart_state[idx].rxfer_size - PHAL_DMA_getRemaining(rx_dma));
-    usart_state[idx].rx_len = received;
-    usart_state[idx].rx_busy = false;
+    uint16_t received = (uint16_t)(usart_state[periph_idx].rxfer_size - PHAL_DMA_getRemaining(rx_dma));
+    usart_state[periph_idx].rx_len = received;
+    usart_state[periph_idx].rx_busy = false;
 
-    if (usart_state[idx].cont_rx) {
-        PHAL_USART_priv_stopRx(periph_idx);
-        PHAL_DMA_setLength(rx_dma, usart_state[idx].rxfer_size);
-        PHAL_USART_priv_flushRx(periph_idx);
+    if (usart_state[periph_idx].cont_rx) {
+        PHAL_USART_priv_stopRx(periph);
+        PHAL_DMA_setLength(rx_dma, usart_state[periph_idx].rxfer_size);
+        PHAL_USART_priv_flushRx(periph);
         PHAL_DMA_restart(rx_dma);
 
-        usart_state[idx].rx_busy = true;
-        PHAL_USART_priv_startRx(periph_idx);
+        usart_state[periph_idx].rx_busy = true;
+        PHAL_USART_priv_startRx(periph);
     } else {
-        PHAL_USART_priv_stopRx(periph_idx);
+        PHAL_USART_priv_stopRx(periph);
     }
 
-    PHAL_USART_rxCallback(idx, received);
+    PHAL_USART_rxCallback(periph_idx, received);
 }
 
-static void PHAL_USART_HandleDMA(PHAL_USART_Idx_t idx) {
-    if (PHAL_USART_priv_txDmaComplete(idx)) {
-        PHAL_DMA_stop(&usart_state[idx].tx_dma);
+static void usart_handle_dma(PHAL_USART_Idx_t periph_idx) {
+    if (PHAL_USART_priv_txDmaComplete(periph_idx)) {
+        PHAL_DMA_stop(&usart_state[periph_idx].tx_dma);
     }
-    PHAL_USART_priv_clearTxDmaFlags(idx);
+    PHAL_USART_priv_clearTxDmaFlags(periph_idx);
 }
 
 [[gnu::weak]] void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph_idx, uint16_t len) {
@@ -228,17 +228,17 @@ static void PHAL_USART_HandleDMA(PHAL_USART_Idx_t idx) {
 
 /* USART interrupt handlers (IDLE line + transmission complete) */
 void USART1_IRQHandler(void) {
-    PHAL_USART_HandleIRQ(USART1_IDX);
+    usart_handle_irq(USART1_IDX);
 }
 
 void USART2_IRQHandler(void) {
-    PHAL_USART_HandleIRQ(USART2_IDX);
+    usart_handle_irq(USART2_IDX);
 }
 
 void USART3_IRQHandler(void) {
-    PHAL_USART_HandleIRQ(USART3_IDX);
+    usart_handle_irq(USART3_IDX);
 }
 
 static void usart_tx_dma_callback(void *ctx) {
-    PHAL_USART_HandleDMA((PHAL_USART_Idx_t)(intptr_t)ctx);
+    usart_handle_dma((PHAL_USART_Idx_t)(intptr_t)ctx);
 }

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -6,13 +6,13 @@
 static void usart_tx_dma_callback(void *ctx);
 
 typedef struct {
-    PHAL_DMA_Handle_t tx_dma;    /*!< TX DMA handle (built in init) */
-    PHAL_DMA_Handle_t rx_dma;    /*!< RX DMA handle (built in init) */
+    PHAL_DMA_Handle_t tx_dma;     /*!< TX DMA handle (built in init) */
+    PHAL_DMA_Handle_t rx_dma;     /*!< RX DMA handle (built in init) */
     volatile uint16_t rxfer_size; /*!< configured RX length (for continuous re-arm) */
-    volatile uint16_t rx_len;    /*!< bytes actually received in the last completed frame */
-    volatile bool tx_busy;       /*!< set when a TX is in flight, cleared by the USART TC ISR */
-    volatile bool rx_busy;       /*!< set while a frame is in flight, cleared by the IDLE-line ISR */
-    bool cont_rx;                /*!< continuous vs one-shot reception */
+    volatile uint16_t rx_len;     /*!< bytes actually received in the last completed frame */
+    volatile bool tx_busy;        /*!< set when a TX is in flight, cleared by the USART TC ISR */
+    volatile bool rx_busy;        /*!< set while a frame is in flight, cleared by the IDLE-line ISR */
+    bool cont_rx;                 /*!< continuous vs one-shot reception */
 } PHAL_USART_state_t;
 
 static PHAL_USART_state_t usart_state[NUM_USART];

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -60,14 +60,11 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
     }
 
     PHAL_DMA_Handle_t *tx_dma = &usart_state[periph_idx].tx_dma;
-    bool stopped     = PHAL_DMA_stop(tx_dma);
-    bool length_set  = PHAL_DMA_setLength(tx_dma, len);
-    bool address_set = PHAL_DMA_setMemAddress(tx_dma, (uint32_t)data);
-    bool restarted   = PHAL_DMA_restart(tx_dma);
-
-    if (!(stopped && length_set && address_set && restarted)) {
+    PHAL_DMA_stop(tx_dma);
+    if (!PHAL_DMA_setLength(tx_dma, len) || !PHAL_DMA_setMemAddress(tx_dma, (uint32_t)data)) {
         return false;
     }
+    PHAL_DMA_restart(tx_dma);
 
     usart_state[periph_idx].tx_busy = true;
 
@@ -97,17 +94,14 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, boo
     usart_state[periph_idx].rx_len = 0;
 
     PHAL_DMA_Handle_t *rx_dma = &usart_state[periph_idx].rx_dma;
-    bool stopped     = PHAL_DMA_stop(rx_dma);
-    bool address_set = PHAL_DMA_setMemAddress(rx_dma, (uint32_t)data);
-    bool length_set  = PHAL_DMA_setLength(rx_dma, len);
+    PHAL_DMA_stop(rx_dma);
+    if (!PHAL_DMA_setMemAddress(rx_dma, (uint32_t)data) || !PHAL_DMA_setLength(rx_dma, len)) {
+        return false;
+    }
 
     PHAL_USART_priv_flushRx(periph);
 
-    bool restarted = PHAL_DMA_restart(rx_dma);
-
-    if (!(stopped && address_set && length_set && restarted)) {
-        return false;
-    }
+    PHAL_DMA_restart(rx_dma);
 
     usart_state[periph_idx].rx_busy = true;
     PHAL_USART_priv_startRx(periph);

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -61,9 +61,8 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
 
     PHAL_DMA_Handle_t *tx_dma = &usart_state[periph_idx].tx_dma;
     PHAL_DMA_stop(tx_dma);
-    if (!PHAL_DMA_setLength(tx_dma, len) || !PHAL_DMA_setMemAddress(tx_dma, (uint32_t)data)) {
-        return false;
-    }
+    (void)PHAL_DMA_setLength(tx_dma, len);
+    (void)PHAL_DMA_setMemAddress(tx_dma, (uint32_t)data);
     PHAL_DMA_restart(tx_dma);
 
     usart_state[periph_idx].tx_busy = true;
@@ -82,9 +81,8 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
  * @param cont Enable continuous RX. When set, call this once and the HAL keeps
  *             receiving frames of the same maximum length, invoking
  *             PHAL_USART_rxCallback after each.
- * @return true if every DMA reconfiguration step succeeded, false otherwise
  */
-bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, bool cont) {
+void PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, bool cont) {
     USART_TypeDef *periph = PHAL_USART_priv_periph(periph_idx);
 
     PHAL_USART_priv_stopRx(periph);
@@ -95,9 +93,8 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, boo
 
     PHAL_DMA_Handle_t *rx_dma = &usart_state[periph_idx].rx_dma;
     PHAL_DMA_stop(rx_dma);
-    if (!PHAL_DMA_setMemAddress(rx_dma, (uint32_t)data) || !PHAL_DMA_setLength(rx_dma, len)) {
-        return false;
-    }
+    (void)PHAL_DMA_setMemAddress(rx_dma, (uint32_t)data);
+    (void)PHAL_DMA_setLength(rx_dma, len);
 
     PHAL_USART_priv_flushRx(periph);
 
@@ -105,8 +102,6 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, boo
 
     usart_state[periph_idx].rx_busy = true;
     PHAL_USART_priv_startRx(periph);
-
-    return true;
 }
 
 /**
@@ -153,16 +148,13 @@ bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t 
  * @param periph_idx Which USART peripheral to receive on
  * @param data Buffer to receive into
  * @param len Number of bytes to receive
- * @return true if the reception completed, false if it failed to start
  */
-bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
-    if (!PHAL_USART_rx(periph_idx, data, len, false)) return false;
+void PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
+    PHAL_USART_rx(periph_idx, data, len, false);
 
     while (usart_state[periph_idx].rx_busy) {
         __asm__("nop");
     }
-
-    return true;
 }
 
 static void usart_handle_irq(PHAL_USART_Idx_t periph_idx) {
@@ -196,7 +188,7 @@ static void usart_handle_irq(PHAL_USART_Idx_t periph_idx) {
 
     if (usart_state[periph_idx].cont_rx) {
         PHAL_USART_priv_stopRx(periph);
-        PHAL_DMA_setLength(rx_dma, usart_state[periph_idx].rxfer_size);
+        (void)PHAL_DMA_setLength(rx_dma, usart_state[periph_idx].rxfer_size);
         PHAL_USART_priv_flushRx(periph);
         PHAL_DMA_restart(rx_dma);
 

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -39,6 +39,10 @@ bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t
     bool tx_ready = PHAL_DMA_initWithCallback(&usart_state[idx].tx_dma, usart_tx_dma_callback, (void *)(intptr_t)idx);
     bool rx_ready = PHAL_DMA_init(&usart_state[idx].rx_dma);
 
+    if (tx_ready && rx_ready) {
+        PHAL_USART_priv_enableIrq(idx);
+    }
+
     return tx_ready && rx_ready;
 }
 

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -20,27 +20,25 @@ static PHAL_USART_state_t usart_state[NUM_USART];
 /**
  * @brief Initialize a USART peripheral for DMA-driven communication.
  *
- * @param periph Which USART peripheral to initialize
+ * @param periph_idx Which USART peripheral to initialize
  * @param baud_rate Desired baud rate
  * @param clock_rate Frequency (Hz) of the bus clock feeding this USART (APB1/APB2)
  * @return true on success, false if DMA init failed
  */
-bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t clock_rate) {
-    ssize_t idx = periph;
-
-    PHAL_USART_priv_configure(idx, baud_rate, clock_rate);
-    PHAL_USART_priv_buildDma(idx, &usart_state[idx].tx_dma, &usart_state[idx].rx_dma);
+bool PHAL_USART_init(PHAL_USART_Idx_t periph_idx, uint32_t baud_rate, const uint32_t clock_rate) {
+    PHAL_USART_priv_configure(periph_idx, baud_rate, clock_rate);
+    PHAL_USART_priv_buildDma(periph_idx, &usart_state[periph_idx].tx_dma, &usart_state[periph_idx].rx_dma);
 
     // Both, not short-circuited: a failed TX claim must not leave the RX
     // handle uninitialized, since that failure mode is silent until the first
     // rx call returns false for no visible reason.
     // TX completion -> PHAL_USART_HandleDMA
     // RX completion comes from the USART IDLE-line interrupt
-    bool tx_ready = PHAL_DMA_initWithCallback(&usart_state[idx].tx_dma, usart_tx_dma_callback, (void *)(intptr_t)idx);
-    bool rx_ready = PHAL_DMA_init(&usart_state[idx].rx_dma);
+    bool tx_ready = PHAL_DMA_initWithCallback(&usart_state[periph_idx].tx_dma, usart_tx_dma_callback, (void *)(intptr_t)periph_idx);
+    bool rx_ready = PHAL_DMA_init(&usart_state[periph_idx].rx_dma);
 
     if (tx_ready && rx_ready) {
-        PHAL_USART_priv_enableIrq(idx);
+        PHAL_USART_priv_enableIrq(periph_idx);
     }
 
     return tx_ready && rx_ready;
@@ -49,20 +47,18 @@ bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t
 /**
  * @brief Start a DMA-based transmission.
  *
- * @param periph Which USART peripheral to transmit on
+ * @param periph_idx Which USART peripheral to transmit on
  * @param data Buffer to send
  * @param len Number of bytes to send
  * @return true if every DMA reconfiguration step succeeded, false if a
  *         transmission is already in flight or a step failed
  */
-bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
-    ssize_t idx = periph;
-
-    if (usart_state[idx].tx_busy) {
+bool PHAL_USART_tx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
+    if (usart_state[periph_idx].tx_busy) {
         return false;
     }
 
-    PHAL_DMA_Handle_t *tx_dma = &usart_state[idx].tx_dma;
+    PHAL_DMA_Handle_t *tx_dma = &usart_state[periph_idx].tx_dma;
     bool stopped     = PHAL_DMA_stop(tx_dma);
     bool length_set  = PHAL_DMA_setLength(tx_dma, len);
     bool address_set = PHAL_DMA_setMemAddress(tx_dma, (uint32_t)data);
@@ -72,9 +68,9 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
         return false;
     }
 
-    usart_state[idx].tx_busy = true;
+    usart_state[periph_idx].tx_busy = true;
 
-    PHAL_USART_priv_startTx(PHAL_USART_priv_periph(idx));
+    PHAL_USART_priv_startTx(PHAL_USART_priv_periph(periph_idx));
 
     return true;
 }
@@ -82,7 +78,7 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
 /**
  * @brief Start a DMA-based reception, completed on the IDLE line.
  *
- * @param periph Which USART peripheral to receive on
+ * @param periph_idx Which USART peripheral to receive on
  * @param data Buffer to receive into
  * @param len Maximum number of bytes to receive (buffer size)
  * @param cont Enable continuous RX. When set, call this once and the HAL keeps
@@ -90,17 +86,16 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
  *             PHAL_USART_rxCallback after each.
  * @return true if every DMA reconfiguration step succeeded, false otherwise
  */
-bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len, bool cont) {
-    ssize_t idx = periph;
-    USART_TypeDef *hw = PHAL_USART_priv_periph(idx);
+bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, bool cont) {
+    USART_TypeDef *hw = PHAL_USART_priv_periph(periph_idx);
 
     PHAL_USART_priv_stopRx(hw);
 
-    usart_state[idx].cont_rx = cont;
-    usart_state[idx].rxfer_size = len;
-    usart_state[idx].rx_len = 0;
+    usart_state[periph_idx].cont_rx = cont;
+    usart_state[periph_idx].rxfer_size = len;
+    usart_state[periph_idx].rx_len = 0;
 
-    PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
+    PHAL_DMA_Handle_t *rx_dma = &usart_state[periph_idx].rx_dma;
     bool stopped     = PHAL_DMA_stop(rx_dma);
     bool address_set = PHAL_DMA_setMemAddress(rx_dma, (uint32_t)data);
     bool length_set  = PHAL_DMA_setLength(rx_dma, len);
@@ -113,7 +108,7 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len, bool co
         return false;
     }
 
-    usart_state[idx].rx_busy = true;
+    usart_state[periph_idx].rx_busy = true;
     PHAL_USART_priv_startRx(hw);
 
     return true;
@@ -122,35 +117,35 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len, bool co
 /**
  * @brief Check whether a transmission is still in progress.
  *
- * @param periph Which USART peripheral to check
+ * @param periph_idx Which USART peripheral to check
  * @return true if a transmission is in flight, false otherwise
  */
-bool PHAL_USART_txBusy(PHAL_USART_Idx_t periph) {
-    return usart_state[periph].tx_busy;
+bool PHAL_USART_txBusy(PHAL_USART_Idx_t periph_idx) {
+    return usart_state[periph_idx].tx_busy;
 }
 
 /**
  * @brief Number of bytes received in the last completed frame.
  *
- * @param periph Which USART peripheral to query
+ * @param periph_idx Which USART peripheral to query
  * @return byte count, valid once PHAL_USART_rxCallback has fired
  */
-uint16_t PHAL_USART_rxCount(PHAL_USART_Idx_t periph) {
-    return usart_state[periph].rx_len;
+uint16_t PHAL_USART_rxCount(PHAL_USART_Idx_t periph_idx) {
+    return usart_state[periph_idx].rx_len;
 }
 
 /**
  * @brief Transmit data, blocking until the transfer completes.
  *
- * @param periph Which USART peripheral to transmit on
+ * @param periph_idx Which USART peripheral to transmit on
  * @param data Buffer to send
  * @param len Number of bytes to send
  * @return true if the transfer completed, false if it failed to start
  */
-bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
-    if (!PHAL_USART_tx(periph, data, len)) return false;
+bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
+    if (!PHAL_USART_tx(periph_idx, data, len)) return false;
 
-    while (PHAL_USART_txBusy(periph)) {
+    while (PHAL_USART_txBusy(periph_idx)) {
         __asm__("nop");
     }
     
@@ -160,15 +155,15 @@ bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len)
 /**
  * @brief Receive data, blocking until a one-shot reception completes.
  *
- * @param periph Which USART peripheral to receive on
+ * @param periph_idx Which USART peripheral to receive on
  * @param data Buffer to receive into
  * @param len Number of bytes to receive
  * @return true if the reception completed, false if it failed to start
  */
-bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len) {
-    if (!PHAL_USART_rx(periph, data, len, false)) return false;
+bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len) {
+    if (!PHAL_USART_rx(periph_idx, data, len, false)) return false;
 
-    while (usart_state[periph].rx_busy) {
+    while (usart_state[periph_idx].rx_busy) {
         __asm__("nop");
     }
 
@@ -176,18 +171,18 @@ bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len)
 }
 
 static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
-    USART_TypeDef *periph = PHAL_USART_priv_periph(idx);
+    USART_TypeDef *periph_idx = PHAL_USART_priv_periph(idx);
 
-    if (PHAL_USART_priv_txCompleteActive(periph)) {
-        PHAL_USART_priv_finishTx(periph);
+    if (PHAL_USART_priv_txCompleteActive(periph_idx)) {
+        PHAL_USART_priv_finishTx(periph_idx);
         usart_state[idx].tx_busy = false;
     }
 
-    if (!PHAL_USART_priv_idleActive(periph)) {
+    if (!PHAL_USART_priv_idleActive(periph_idx)) {
         return;
     }
 
-    PHAL_USART_priv_clearIdle(periph);
+    PHAL_USART_priv_clearIdle(periph_idx);
 
     PHAL_DMA_Handle_t *rx_dma = &usart_state[idx].rx_dma;
 
@@ -205,15 +200,15 @@ static void PHAL_USART_HandleIRQ(PHAL_USART_Idx_t idx) {
     usart_state[idx].rx_busy = false;
 
     if (usart_state[idx].cont_rx) {
-        PHAL_USART_priv_stopRx(periph);
+        PHAL_USART_priv_stopRx(periph_idx);
         PHAL_DMA_setLength(rx_dma, usart_state[idx].rxfer_size);
-        PHAL_USART_priv_flushRx(periph);
+        PHAL_USART_priv_flushRx(periph_idx);
         PHAL_DMA_restart(rx_dma);
 
         usart_state[idx].rx_busy = true;
-        PHAL_USART_priv_startRx(periph);
+        PHAL_USART_priv_startRx(periph_idx);
     } else {
-        PHAL_USART_priv_stopRx(periph);
+        PHAL_USART_priv_stopRx(periph_idx);
     }
 
     PHAL_USART_rxCallback(idx, received);
@@ -226,8 +221,8 @@ static void PHAL_USART_HandleDMA(PHAL_USART_Idx_t idx) {
     PHAL_USART_priv_clearTxDmaFlags(idx);
 }
 
-[[gnu::weak]] void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph, uint16_t len) {
-    (void)periph;
+[[gnu::weak]] void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph_idx, uint16_t len) {
+    (void)periph_idx;
     (void)len;
 }
 

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -210,10 +210,11 @@ static void usart_handle_irq(PHAL_USART_Idx_t periph_idx) {
 }
 
 static void usart_handle_dma(PHAL_USART_Idx_t periph_idx) {
-    if (PHAL_USART_priv_txDmaComplete(periph_idx)) {
+    PHAL_DMA_Handle_t *tx_dma = &usart_state[periph_idx].tx_dma;
+    if (PHAL_DMA_isComplete(tx_dma)) {
         PHAL_DMA_stop(&usart_state[periph_idx].tx_dma);
     }
-    PHAL_USART_priv_clearTxDmaFlags(periph_idx);
+    PHAL_DMA_clearFlags(tx_dma);
 }
 
 static void usart_tx_dma_callback(void *ctx) {

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -3,6 +3,7 @@
 
 #include "common/phal_G4/dma/dma.h"
 
+// Forward declaration of the DMA callback handler for TX completion
 static void usart_tx_dma_callback(void *ctx);
 
 typedef struct {
@@ -221,6 +222,10 @@ static void usart_handle_dma(PHAL_USART_Idx_t periph_idx) {
     PHAL_USART_priv_clearTxDmaFlags(periph_idx);
 }
 
+static void usart_tx_dma_callback(void *ctx) {
+    usart_handle_dma((PHAL_USART_Idx_t)(intptr_t)ctx);
+}
+
 [[gnu::weak]] void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph_idx, uint16_t len) {
     (void)periph_idx;
     (void)len;
@@ -237,8 +242,4 @@ void USART2_IRQHandler(void) {
 
 void USART3_IRQHandler(void) {
     usart_handle_irq(USART3_IDX);
-}
-
-static void usart_tx_dma_callback(void *ctx) {
-    usart_handle_dma((PHAL_USART_Idx_t)(intptr_t)ctx);
 }

--- a/firmware/common/phal_G4/usart/usart.c
+++ b/firmware/common/phal_G4/usart/usart.c
@@ -3,6 +3,8 @@
 
 #include "common/phal_G4/dma/dma.h"
 
+static void usart_tx_dma_callback(void *ctx);
+
 typedef struct {
     PHAL_DMA_Handle_t tx_dma;    /*!< TX DMA handle (built in init) */
     PHAL_DMA_Handle_t rx_dma;    /*!< RX DMA handle (built in init) */
@@ -32,12 +34,10 @@ bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t
     // Both, not short-circuited: a failed TX claim must not leave the RX
     // handle uninitialized, since that failure mode is silent until the first
     // rx call returns false for no visible reason.
-    bool tx_ready = PHAL_DMA_init(&usart_state[idx].tx_dma);
+    // TX completion -> PHAL_USART_HandleDMA
+    // RX completion comes from the USART IDLE-line interrupt
+    bool tx_ready = PHAL_DMA_initWithCallback(&usart_state[idx].tx_dma, usart_tx_dma_callback, (void *)(intptr_t)idx);
     bool rx_ready = PHAL_DMA_init(&usart_state[idx].rx_dma);
-
-    if (tx_ready && rx_ready) {
-        PHAL_USART_priv_enableIrqs(idx);
-    }
 
     return tx_ready && rx_ready;
 }
@@ -227,35 +227,6 @@ static void PHAL_USART_HandleDMA(PHAL_USART_Idx_t idx) {
     (void)len;
 }
 
-/* DMA transfer-complete interrupt handlers (TX channels) */
-[[gnu::weak]]
-void DMA1_Channel7_IRQHandler(void) {
-    PHAL_USART_HandleDMA(USART1_IDX);
-}
-
-[[gnu::weak]]
-void DMA1_Channel4_IRQHandler(void) {
-    PHAL_USART_HandleDMA(USART2_IDX);
-}
-
-/// Service USART3 RX when it owns DMA1 channel 1.
-void PHAL_USART_DMA1_Channel1_IRQHandler(void) {
-    PHAL_USART_HandleDMA(USART3_IDX);
-}
-
-// ADC provides the strong shared vector when linked and delegates here when
-// ADC1 does not own the channel. This weak vector covers USART-only builds.
-[[gnu::weak]]
-void DMA1_Channel1_IRQHandler(void) {
-    PHAL_USART_DMA1_Channel1_IRQHandler();
-}
-
-/* USART Interrupt Handlers */
-[[gnu::weak]]
-void DMA1_Channel2_IRQHandler(void) {
-    PHAL_USART_HandleDMA(USART3_IDX);
-}
-
 /* USART interrupt handlers (IDLE line + transmission complete) */
 void USART1_IRQHandler(void) {
     PHAL_USART_HandleIRQ(USART1_IDX);
@@ -267,4 +238,8 @@ void USART2_IRQHandler(void) {
 
 void USART3_IRQHandler(void) {
     PHAL_USART_HandleIRQ(USART3_IDX);
+}
+
+static void usart_tx_dma_callback(void *ctx) {
+    PHAL_USART_HandleDMA((PHAL_USART_Idx_t)(intptr_t)ctx);
 }

--- a/firmware/common/phal_G4/usart/usart.h
+++ b/firmware/common/phal_G4/usart/usart.h
@@ -4,9 +4,9 @@
 #include "common/phal_G4/phal_G4.h"
 
 typedef enum {
-    USART1_IDX,
-    USART2_IDX,
-    USART3_IDX,
+    USART1_IDX = 0,
+    USART2_IDX = 1,
+    USART3_IDX = 2,
     NUM_USART
 } PHAL_USART_Idx_t;
 
@@ -24,12 +24,12 @@ typedef enum {
  * Call once per USART before any tx/rx. The USART GPIO pins must already be
  * configured by the caller.
  *
- * @param periph Which USART peripheral to initialize
+ * @param periph_idx Which USART peripheral to initialize
  * @param baud_rate Desired baud rate
  * @param clock_rate Frequency (Hz) of the bus clock feeding this USART (APBx)
  * @return true on success, false if DMA init failed
  */
-bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t clock_rate);
+bool PHAL_USART_init(PHAL_USART_Idx_t periph_idx, uint32_t baud_rate, const uint32_t clock_rate);
 
 /**
  * @brief Start a transmission using DMA.
@@ -37,18 +37,18 @@ bool PHAL_USART_init(PHAL_USART_Idx_t periph, uint32_t baud_rate, const uint32_t
  * Fails rather than truncating a transfer already in flight - poll
  * PHAL_USART_txBusy() (or use PHAL_USART_txBlocking) before calling again.
  *
- * @param periph Which USART peripheral to transmit on
+ * @param periph_idx Which USART peripheral to transmit on
  * @param data The address of the data to send
  * @param len Number of bytes.
  * @return true if every DMA reconfiguration step succeeded, false if a
  *         transmission is already in flight or a step failed
  */
-bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len);
+bool PHAL_USART_tx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len);
 
 /**
  * @brief Start a reception using DMA of a specific length.
  *
- * @param periph Which USART peripheral to receive on
+ * @param periph_idx Which USART peripheral to receive on
  * @param data The address to put the received data
  * @param len Maximum number of bytes (the buffer size). A frame shorter than
  *            this still completes on the IDLE line; the actual count is
@@ -59,7 +59,7 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len);
  *             maximum length, invoking PHAL_USART_rxCallback after each.
  * @return true if every DMA reconfiguration step succeeded, false otherwise
  */
-bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len, bool cont);
+bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, bool cont);
 
 /**
  * @brief Returns whether the USART peripheral is currently transmitting data.
@@ -68,10 +68,10 @@ bool PHAL_USART_rx(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len, bool co
  * the last bit has left the wire - not merely until the DMA has finished
  * writing to the data register.
  *
- * @param periph Which USART peripheral to check
+ * @param periph_idx Which USART peripheral to check
  * @return true if the peripheral is currently sending a message, false otherwise
  */
-bool PHAL_USART_txBusy(PHAL_USART_Idx_t periph);
+bool PHAL_USART_txBusy(PHAL_USART_Idx_t periph_idx);
 
 /**
  * @brief Number of bytes received in the last completed frame.
@@ -80,11 +80,11 @@ bool PHAL_USART_txBusy(PHAL_USART_Idx_t periph);
  * the length passed to PHAL_USART_rx. Anything past this count in the buffer
  * is leftover from an earlier frame.
  *
- * @param periph Which USART peripheral to query
+ * @param periph_idx Which USART peripheral to query
  * @return byte count, valid once PHAL_USART_rxCallback has fired (or
  *         PHAL_USART_rxBlocking has returned)
  */
-uint16_t PHAL_USART_rxCount(PHAL_USART_Idx_t periph);
+uint16_t PHAL_USART_rxCount(PHAL_USART_Idx_t periph_idx);
 
 /**
  * @brief Transmit data, blocking until the transfer completes.
@@ -92,12 +92,12 @@ uint16_t PHAL_USART_rxCount(PHAL_USART_Idx_t periph);
  * Starts a DMA transmission (see PHAL_USART_tx) and busy-waits until the
  * USART reports the frame fully shifted out. Do not call from an ISR.
  *
- * @param periph Which USART peripheral to transmit on
+ * @param periph_idx Which USART peripheral to transmit on
  * @param data Buffer to send
  * @param len Number of bytes to send
  * @return true if the transfer completed, false if it failed to start
  */
-bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len);
+bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len);
 
 /**
  * @brief Receive data, blocking until a one-shot reception completes.
@@ -106,21 +106,21 @@ bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len)
  * the IDLE-line ISR signals the frame is complete. Call PHAL_USART_rxCount()
  * afterwards for the byte count. Do not call from an ISR.
  *
- * @param periph Which USART peripheral to receive on
+ * @param periph_idx Which USART peripheral to receive on
  * @param data Buffer to receive into
  * @param len Maximum number of bytes to receive
  * @return true if the reception completed, false if it failed to start
  */
-bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph, uint8_t *data, uint16_t len);
+bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len);
 
 /**
  * @brief Weak callback invoked when a full RX frame is received. Override in
  *        application code. Runs in ISR context, so keep it light.
  *
- * @param periph Which USART peripheral received the frame
+ * @param periph_idx Which USART peripheral received the frame
  * @param len Number of bytes in this frame. Bytes past this offset in the
  *            buffer are stale and must not be decoded.
  */
-extern void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph, uint16_t len);
+extern void PHAL_USART_rxCallback(PHAL_USART_Idx_t periph_idx, uint16_t len);
 
 #endif // __PHAL_G4_USART_H__

--- a/firmware/common/phal_G4/usart/usart.h
+++ b/firmware/common/phal_G4/usart/usart.h
@@ -57,9 +57,8 @@ bool PHAL_USART_tx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len);
  * @param cont Enable continuous RX using the IDLE-line interrupt. When set, call
  *             this function once and the HAL keeps receiving frames of the same
  *             maximum length, invoking PHAL_USART_rxCallback after each.
- * @return true if every DMA reconfiguration step succeeded, false otherwise
  */
-bool PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, bool cont);
+void PHAL_USART_rx(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len, bool cont);
 
 /**
  * @brief Returns whether the USART peripheral is currently transmitting data.
@@ -109,9 +108,8 @@ bool PHAL_USART_txBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t 
  * @param periph_idx Which USART peripheral to receive on
  * @param data Buffer to receive into
  * @param len Maximum number of bytes to receive
- * @return true if the reception completed, false if it failed to start
  */
-bool PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len);
+void PHAL_USART_rxBlocking(PHAL_USART_Idx_t periph_idx, uint8_t *data, uint16_t len);
 
 /**
  * @brief Weak callback invoked when a full RX frame is received. Override in

--- a/firmware/common/phal_G4/usart/usart_priv.c
+++ b/firmware/common/phal_G4/usart/usart_priv.c
@@ -7,6 +7,7 @@ static const PHAL_USART_HwMap_t USART_MAP[NUM_USART] = {
         .rcc_reset_rg   = &RCC->APB2RSTR,
         .rcc_reset_msk  = RCC_APB2RSTR_USART1RST,
         .periph         = USART1,
+        .irq            = USART1_IRQn,
         .tx_wiring      = &USART1_TX_DMA_WIRING,
         .rx_wiring      = &USART1_RX_DMA_WIRING,
     },
@@ -16,6 +17,7 @@ static const PHAL_USART_HwMap_t USART_MAP[NUM_USART] = {
         .rcc_reset_rg   = &RCC->APB1RSTR1,
         .rcc_reset_msk  = RCC_APB1RSTR1_USART2RST,
         .periph         = USART2,
+        .irq            = USART2_IRQn,
         .tx_wiring      = &USART2_TX_DMA_WIRING,
         .rx_wiring      = &USART2_RX_DMA_WIRING,
     },
@@ -25,6 +27,7 @@ static const PHAL_USART_HwMap_t USART_MAP[NUM_USART] = {
         .rcc_reset_rg   = &RCC->APB1RSTR1,
         .rcc_reset_msk  = RCC_APB1RSTR1_USART3RST,
         .periph         = USART3,
+        .irq            = USART3_IRQn,
         .tx_wiring      = &USART3_TX_DMA_WIRING,
         .rx_wiring      = &USART3_RX_DMA_WIRING,
     },
@@ -186,4 +189,11 @@ void PHAL_USART_priv_clearTxDmaFlags(ssize_t idx) {
     const PHAL_DMA_Wiring_t *wiring = USART_MAP[idx].tx_wiring;
     uint32_t shift = 4U * (wiring->channel_idx - 1U);
     wiring->periph->IFCR = DMA_IFCR_CGIF1 << shift;
+}
+
+void PHAL_USART_priv_enableIrq(ssize_t idx) {
+    const PHAL_USART_HwMap_t *map = &USART_MAP[idx];
+    
+    NVIC_ClearPendingIRQ(map->irq);
+    NVIC_EnableIRQ(map->irq);
 }

--- a/firmware/common/phal_G4/usart/usart_priv.c
+++ b/firmware/common/phal_G4/usart/usart_priv.c
@@ -7,8 +7,6 @@ static const PHAL_USART_HwMap_t USART_MAP[NUM_USART] = {
         .rcc_reset_rg   = &RCC->APB2RSTR,
         .rcc_reset_msk  = RCC_APB2RSTR_USART1RST,
         .periph         = USART1,
-        .irq            = USART1_IRQn,
-        .tx_dma_irq     = DMA1_Channel7_IRQn,
         .tx_wiring      = &USART1_TX_DMA_WIRING,
         .rx_wiring      = &USART1_RX_DMA_WIRING,
     },
@@ -18,8 +16,6 @@ static const PHAL_USART_HwMap_t USART_MAP[NUM_USART] = {
         .rcc_reset_rg   = &RCC->APB1RSTR1,
         .rcc_reset_msk  = RCC_APB1RSTR1_USART2RST,
         .periph         = USART2,
-        .irq            = USART2_IRQn,
-        .tx_dma_irq     = DMA1_Channel4_IRQn,
         .tx_wiring      = &USART2_TX_DMA_WIRING,
         .rx_wiring      = &USART2_RX_DMA_WIRING,
     },
@@ -29,8 +25,6 @@ static const PHAL_USART_HwMap_t USART_MAP[NUM_USART] = {
         .rcc_reset_rg   = &RCC->APB1RSTR1,
         .rcc_reset_msk  = RCC_APB1RSTR1_USART3RST,
         .periph         = USART3,
-        .irq            = USART3_IRQn,
-        .tx_dma_irq     = DMA1_Channel2_IRQn,
         .tx_wiring      = &USART3_TX_DMA_WIRING,
         .rx_wiring      = &USART3_RX_DMA_WIRING,
     },
@@ -192,14 +186,4 @@ void PHAL_USART_priv_clearTxDmaFlags(ssize_t idx) {
     const PHAL_DMA_Wiring_t *wiring = USART_MAP[idx].tx_wiring;
     uint32_t shift = 4U * (wiring->channel_idx - 1U);
     wiring->periph->IFCR = DMA_IFCR_CGIF1 << shift;
-}
-
-void PHAL_USART_priv_enableIrqs(ssize_t idx) {
-    const PHAL_USART_HwMap_t *map = &USART_MAP[idx];
-    
-    NVIC_ClearPendingIRQ(map->irq);
-    NVIC_EnableIRQ(map->irq);
-
-    NVIC_ClearPendingIRQ(map->tx_dma_irq);
-    NVIC_EnableIRQ(map->tx_dma_irq);
 }

--- a/firmware/common/phal_G4/usart/usart_priv.c
+++ b/firmware/common/phal_G4/usart/usart_priv.c
@@ -50,12 +50,12 @@ static inline void exitCritical(uint32_t previous_interrupt_mask) {
     __set_PRIMASK(previous_interrupt_mask);
 }
 
-USART_TypeDef *PHAL_USART_priv_periph(ssize_t idx) {
-    return USART_MAP[idx].periph;
+USART_TypeDef *PHAL_USART_priv_periph(PHAL_USART_Idx_t periph_idx) {
+    return USART_MAP[periph_idx].periph;
 }
 
-void PHAL_USART_priv_configure(ssize_t idx, uint32_t baud_rate, uint32_t clock_rate) {
-    const PHAL_USART_HwMap_t *map = &USART_MAP[idx];
+void PHAL_USART_priv_configure(PHAL_USART_Idx_t periph_idx, uint32_t baud_rate, uint32_t clock_rate) {
+    const PHAL_USART_HwMap_t *map = &USART_MAP[periph_idx];
     USART_TypeDef *periph = map->periph;
 
     // Pulse the peripheral reset
@@ -88,8 +88,8 @@ void PHAL_USART_priv_configure(ssize_t idx, uint32_t baud_rate, uint32_t clock_r
     periph->ICR = USART_PRIV_RX_FLAG_CLEAR_MSK | USART_ICR_TCCF;
 }
 
-void PHAL_USART_priv_buildDma(ssize_t idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_Handle_t *rx_dma) {
-    const PHAL_USART_HwMap_t *map = &USART_MAP[idx];
+void PHAL_USART_priv_buildDma(PHAL_USART_Idx_t periph_idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_Handle_t *rx_dma) {
+    const PHAL_USART_HwMap_t *map = &USART_MAP[periph_idx];
 
     *tx_dma = (PHAL_DMA_Handle_t) {
         .wiring = map->tx_wiring,
@@ -179,20 +179,20 @@ void PHAL_USART_priv_clearIdle(USART_TypeDef *periph) {
     periph->ICR = USART_ICR_IDLECF;
 }
 
-bool PHAL_USART_priv_txDmaComplete(ssize_t idx) {
-    const PHAL_DMA_Wiring_t *wiring = USART_MAP[idx].tx_wiring;
+bool PHAL_USART_priv_txDmaComplete(PHAL_USART_Idx_t periph_idx) {
+    const PHAL_DMA_Wiring_t *wiring = USART_MAP[periph_idx].tx_wiring;
     uint32_t shift = 4U * (wiring->channel_idx - 1U);
     return (wiring->periph->ISR & (DMA_ISR_TCIF1 << shift)) != 0U;
 }
 
-void PHAL_USART_priv_clearTxDmaFlags(ssize_t idx) {
-    const PHAL_DMA_Wiring_t *wiring = USART_MAP[idx].tx_wiring;
+void PHAL_USART_priv_clearTxDmaFlags(PHAL_USART_Idx_t periph_idx) {
+    const PHAL_DMA_Wiring_t *wiring = USART_MAP[periph_idx].tx_wiring;
     uint32_t shift = 4U * (wiring->channel_idx - 1U);
     wiring->periph->IFCR = DMA_IFCR_CGIF1 << shift;
 }
 
-void PHAL_USART_priv_enableIrq(ssize_t idx) {
-    const PHAL_USART_HwMap_t *map = &USART_MAP[idx];
+void PHAL_USART_priv_enableIrq(PHAL_USART_Idx_t periph_idx) {
+    const PHAL_USART_HwMap_t *map = &USART_MAP[periph_idx];
     
     NVIC_ClearPendingIRQ(map->irq);
     NVIC_EnableIRQ(map->irq);

--- a/firmware/common/phal_G4/usart/usart_priv.c
+++ b/firmware/common/phal_G4/usart/usart_priv.c
@@ -179,18 +179,6 @@ void PHAL_USART_priv_clearIdle(USART_TypeDef *periph) {
     periph->ICR = USART_ICR_IDLECF;
 }
 
-bool PHAL_USART_priv_txDmaComplete(PHAL_USART_Idx_t periph_idx) {
-    const PHAL_DMA_Wiring_t *wiring = USART_MAP[periph_idx].tx_wiring;
-    uint32_t shift = 4U * (wiring->channel_idx - 1U);
-    return (wiring->periph->ISR & (DMA_ISR_TCIF1 << shift)) != 0U;
-}
-
-void PHAL_USART_priv_clearTxDmaFlags(PHAL_USART_Idx_t periph_idx) {
-    const PHAL_DMA_Wiring_t *wiring = USART_MAP[periph_idx].tx_wiring;
-    uint32_t shift = 4U * (wiring->channel_idx - 1U);
-    wiring->periph->IFCR = DMA_IFCR_CGIF1 << shift;
-}
-
 void PHAL_USART_priv_enableIrq(PHAL_USART_Idx_t periph_idx) {
     const PHAL_USART_HwMap_t *map = &USART_MAP[periph_idx];
     

--- a/firmware/common/phal_G4/usart/usart_priv.h
+++ b/firmware/common/phal_G4/usart/usart_priv.h
@@ -49,9 +49,6 @@ bool PHAL_USART_priv_idleActive(USART_TypeDef *periph);
 /// Clear the IDLE flag alone (write-1-to-clear).
 void PHAL_USART_priv_clearIdle(USART_TypeDef *periph);
 
-/// return true if the slot's TX DMA channel signalled transfer complete.
-bool PHAL_USART_priv_txDmaComplete(PHAL_USART_Idx_t periph_idx);
-
 /// Clear all interrupt flags for the slot's TX DMA channel.
 void PHAL_USART_priv_clearTxDmaFlags(PHAL_USART_Idx_t periph_idx);
 

--- a/firmware/common/phal_G4/usart/usart_priv.h
+++ b/firmware/common/phal_G4/usart/usart_priv.h
@@ -18,14 +18,14 @@ typedef struct {
     const PHAL_DMA_Wiring_t *rx_wiring; /*!< fixed DMA wiring for RX (see dma_wiring.h) */
 } PHAL_USART_HwMap_t;
 
-/// @return the peripheral instance for a slot (used by the interrupt handlers).
-USART_TypeDef *PHAL_USART_priv_periph(ssize_t idx);
+/// get the peripheral instance for a slot (used by the interrupt handlers)
+USART_TypeDef *PHAL_USART_priv_periph(PHAL_USART_Idx_t periph_idx);
 
 /// Enable the clock, program 8N1 + baud, and enable the USART + TX-DMA interrupts.
-void PHAL_USART_priv_configure(ssize_t idx, uint32_t baud_rate, uint32_t clock_rate);
+void PHAL_USART_priv_configure(PHAL_USART_Idx_t periph_idx, uint32_t baud_rate, uint32_t clock_rate);
 
 /// Fill the TX and RX DMA handles from the hardware map.
-void PHAL_USART_priv_buildDma(ssize_t idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_Handle_t *rx_dma);
+void PHAL_USART_priv_buildDma(PHAL_USART_Idx_t periph_idx, PHAL_DMA_Handle_t *tx_dma, PHAL_DMA_Handle_t *rx_dma);
 
 void PHAL_USART_priv_startTx(USART_TypeDef *periph);
 
@@ -50,11 +50,11 @@ bool PHAL_USART_priv_idleActive(USART_TypeDef *periph);
 void PHAL_USART_priv_clearIdle(USART_TypeDef *periph);
 
 /// @return true if the slot's TX DMA channel signalled transfer complete.
-bool PHAL_USART_priv_txDmaComplete(ssize_t idx);
+bool PHAL_USART_priv_txDmaComplete(PHAL_USART_Idx_t periph_idx);
 
 /// Clear all interrupt flags for the slot's TX DMA channel.
-void PHAL_USART_priv_clearTxDmaFlags(ssize_t idx);
+void PHAL_USART_priv_clearTxDmaFlags(PHAL_USART_Idx_t periph_idx);
 
-void PHAL_USART_priv_enableIrq(ssize_t idx);
+void PHAL_USART_priv_enableIrq(PHAL_USART_Idx_t periph_idx);
 
 #endif // __PHAL_G4_USART_PRIV_H__

--- a/firmware/common/phal_G4/usart/usart_priv.h
+++ b/firmware/common/phal_G4/usart/usart_priv.h
@@ -13,8 +13,6 @@ typedef struct {
     volatile uint32_t *rcc_reset_rg;    /*!< RCC reset register for this UART */
     uint32_t rcc_reset_msk;             /*!< reset bit within rcc_reset_rg */
     USART_TypeDef *periph;              /*!< peripheral instance */
-    IRQn_Type irq;                      /*!< USART global interrupt (carries IDLE and TC) */
-    IRQn_Type tx_dma_irq;               /*!< NVIC line for the TX DMA channel */
     const PHAL_DMA_Wiring_t *tx_wiring; /*!< fixed DMA wiring for TX (see dma_wiring.h) */
     const PHAL_DMA_Wiring_t *rx_wiring; /*!< fixed DMA wiring for RX (see dma_wiring.h) */
 } PHAL_USART_HwMap_t;
@@ -55,7 +53,5 @@ bool PHAL_USART_priv_txDmaComplete(ssize_t idx);
 
 /// Clear all interrupt flags for the slot's TX DMA channel.
 void PHAL_USART_priv_clearTxDmaFlags(ssize_t idx);
-
-void PHAL_USART_priv_enableIrqs(ssize_t idx);
 
 #endif // __PHAL_G4_USART_PRIV_H__

--- a/firmware/common/phal_G4/usart/usart_priv.h
+++ b/firmware/common/phal_G4/usart/usart_priv.h
@@ -13,6 +13,7 @@ typedef struct {
     volatile uint32_t *rcc_reset_rg;    /*!< RCC reset register for this UART */
     uint32_t rcc_reset_msk;             /*!< reset bit within rcc_reset_rg */
     USART_TypeDef *periph;              /*!< peripheral instance */
+    IRQn_Type irq;                      /*!< USART global interrupt (carries IDLE and TC) */
     const PHAL_DMA_Wiring_t *tx_wiring; /*!< fixed DMA wiring for TX (see dma_wiring.h) */
     const PHAL_DMA_Wiring_t *rx_wiring; /*!< fixed DMA wiring for RX (see dma_wiring.h) */
 } PHAL_USART_HwMap_t;
@@ -53,5 +54,7 @@ bool PHAL_USART_priv_txDmaComplete(ssize_t idx);
 
 /// Clear all interrupt flags for the slot's TX DMA channel.
 void PHAL_USART_priv_clearTxDmaFlags(ssize_t idx);
+
+void PHAL_USART_priv_enableIrq(ssize_t idx);
 
 #endif // __PHAL_G4_USART_PRIV_H__

--- a/firmware/common/phal_G4/usart/usart_priv.h
+++ b/firmware/common/phal_G4/usart/usart_priv.h
@@ -18,7 +18,7 @@ typedef struct {
     const PHAL_DMA_Wiring_t *rx_wiring; /*!< fixed DMA wiring for RX (see dma_wiring.h) */
 } PHAL_USART_HwMap_t;
 
-/// get the peripheral instance for a slot (used by the interrupt handlers)
+/// Get the peripheral instance for a slot (used by the interrupt handlers)
 USART_TypeDef *PHAL_USART_priv_periph(PHAL_USART_Idx_t periph_idx);
 
 /// Enable the clock, program 8N1 + baud, and enable the USART + TX-DMA interrupts.
@@ -43,13 +43,13 @@ void PHAL_USART_priv_stopRx(USART_TypeDef *periph);
 /// Discard anything sitting in RDR and clear IDLE plus every RX error flag.
 void PHAL_USART_priv_flushRx(USART_TypeDef *periph);
 
-/// @return true if the IDLE-line flag is set (an RX frame just completed).
+/// return true if the IDLE-line flag is set (an RX frame just completed).
 bool PHAL_USART_priv_idleActive(USART_TypeDef *periph);
 
 /// Clear the IDLE flag alone (write-1-to-clear).
 void PHAL_USART_priv_clearIdle(USART_TypeDef *periph);
 
-/// @return true if the slot's TX DMA channel signalled transfer complete.
+/// return true if the slot's TX DMA channel signalled transfer complete.
 bool PHAL_USART_priv_txDmaComplete(PHAL_USART_Idx_t periph_idx);
 
 /// Clear all interrupt flags for the slot's TX DMA channel.

--- a/firmware/common/phal_G4/usart/usart_priv.h
+++ b/firmware/common/phal_G4/usart/usart_priv.h
@@ -49,9 +49,7 @@ bool PHAL_USART_priv_idleActive(USART_TypeDef *periph);
 /// Clear the IDLE flag alone (write-1-to-clear).
 void PHAL_USART_priv_clearIdle(USART_TypeDef *periph);
 
-/// Clear all interrupt flags for the slot's TX DMA channel.
-void PHAL_USART_priv_clearTxDmaFlags(PHAL_USART_Idx_t periph_idx);
-
+/// Enable the USART global interrupt (carries IDLE and TC)
 void PHAL_USART_priv_enableIrq(PHAL_USART_Idx_t periph_idx);
 
 #endif // __PHAL_G4_USART_PRIV_H__

--- a/firmware/source/g4_testing/spi_test.c
+++ b/firmware/source/g4_testing/spi_test.c
@@ -7,7 +7,6 @@
 #include "common/phal_G4/dma/dma.h"
 #include "common/phal_G4/gpio/gpio.h"
 #include "common/phal_G4/rcc/rcc.h"
-#include "common/phal_G4/spi/spi_priv.h"
 #include "common/phal_G4/spi/spi.h"
 #include "common/utils/countof.h"
 
@@ -47,8 +46,6 @@ static uint8_t slave_rx[XFER_LEN];
 static PHAL_DMA_Handle_t spi1_rx_dma = {
     .wiring = &SPI1_RX_DMA_WIRING,
     .params = {
-        .mem_addr  = (uint32_t)master_rx,
-        .tx_size   = XFER_LEN,
         .priority  = DMA_PRIORITY_HIGH,
         .mode      = DMA_MODE_NORMAL,
         .mem_inc   = true,
@@ -59,8 +56,6 @@ static PHAL_DMA_Handle_t spi1_rx_dma = {
 static PHAL_DMA_Handle_t spi1_tx_dma = {
     .wiring = &SPI1_TX_DMA_WIRING,
     .params = {
-        .mem_addr  = (uint32_t)master_tx,
-        .tx_size   = XFER_LEN,
         .priority  = DMA_PRIORITY_HIGH,
         .mode      = DMA_MODE_NORMAL,
         .mem_inc   = true,
@@ -71,8 +66,6 @@ static PHAL_DMA_Handle_t spi1_tx_dma = {
 static PHAL_DMA_Handle_t spi2_rx_dma = {
     .wiring = &SPI2_RX_DMA_WIRING,
     .params = {
-        .mem_addr  = (uint32_t)slave_rx,
-        .tx_size   = XFER_LEN,
         .priority  = DMA_PRIORITY_HIGH,
         .mode      = DMA_MODE_NORMAL,
         .mem_inc   = true,
@@ -83,8 +76,6 @@ static PHAL_DMA_Handle_t spi2_rx_dma = {
 static PHAL_DMA_Handle_t spi2_tx_dma = {
     .wiring = &SPI2_TX_DMA_WIRING,
     .params = {
-        .mem_addr  = (uint32_t)slave_tx,
-        .tx_size   = XFER_LEN,
         .priority  = DMA_PRIORITY_HIGH,
         .mode      = DMA_MODE_NORMAL,
         .mem_inc   = true,

--- a/firmware/source/g4_testing/usart_test.c
+++ b/firmware/source/g4_testing/usart_test.c
@@ -1,5 +1,4 @@
 #include "g4_testing.h"
-#include "stm32g474xx.h"
 #if (G4_TESTING_CHOSEN == TEST_USART)
 
 #include <stdint.h>
@@ -155,9 +154,7 @@ static bool buffers_equal(usart_subtest_id_t id, const uint8_t *expected, const 
 static bool run_roundtrip(PHAL_USART_Idx_t periph, usart_subtest_id_t id, uint8_t seed) {
     prep_frame(seed);
 
-    if (!PHAL_USART_rx(periph, rx_buf, FRAME_LEN, false)) {
-        return record_failure(id, TIMEOUT_MARKER, 0, 0); // rxDMA failed to arm
-    }
+    PHAL_USART_rx(periph, rx_buf, FRAME_LEN, false);
 
     uint32_t before = rx_frame_success_count;
     if (!PHAL_USART_tx(periph, tx_buf, FRAME_LEN)) {
@@ -182,9 +179,7 @@ static bool test_usart3_roundtrip(void) { return run_roundtrip(USART3_IDX, SUBTE
 static bool test_txBl_blocking_send(void) {
     prep_frame(0xD0);
 
-    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false)) {
-        return record_failure(SUBTEST_TXBL, TIMEOUT_MARKER, 0, 0);
-    }
+    PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false);
 
     uint32_t before = rx_frame_success_count;
     if (!PHAL_USART_txBlocking(TEST_PERIPH, tx_buf, FRAME_LEN)) {
@@ -208,9 +203,7 @@ static bool test_rxBl_blocking_receive(void) {
     if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_RXBL, TIMEOUT_MARKER, 0, 0);
     }
-    if (!PHAL_USART_rxBlocking(TEST_PERIPH, rx_buf, FRAME_LEN)) {
-        return record_failure(SUBTEST_RXBL, TIMEOUT_MARKER, 0, 1); // rxBl reported failure to start
-    }
+    PHAL_USART_rxBlocking(TEST_PERIPH, rx_buf, FRAME_LEN);
 
     return buffers_equal(SUBTEST_RXBL, tx_buf, rx_buf, FRAME_LEN);
 }
@@ -244,9 +237,7 @@ static bool test_txBusy_tracks_transfer(void) {
  */
 static bool test_oneshot_rx_does_not_rearm(void) {
     prep_frame(0x10);
-    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false)) {
-        return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 0);
-    }
+    PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false);
 
     uint32_t before = rx_frame_success_count;
     if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
@@ -275,9 +266,8 @@ static bool test_oneshot_rx_does_not_rearm(void) {
 
     // Re-arming should cleanly capture the next frame.
     memset(rx_buf, 0, FRAME_LEN);
-    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false)) {
-        return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 5);
-    }
+    PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, false);
+
     fill_pattern(tx_buf, FRAME_LEN, 0x12);
     if (!PHAL_USART_tx(TEST_PERIPH, tx_buf, FRAME_LEN)) {
         return record_failure(SUBTEST_ONESHOT, TIMEOUT_MARKER, 0, 6);
@@ -299,9 +289,7 @@ static constexpr uint32_t CONT_RX_FRAMES = 8;
  */
 static bool test_continuous_rx_multiframe(void) {
     memset(rx_buf, 0, FRAME_LEN);
-    if (!PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, true)) {
-        return record_failure(SUBTEST_CONTINUOUS, TIMEOUT_MARKER, 0, 0);
-    }
+    PHAL_USART_rx(TEST_PERIPH, rx_buf, FRAME_LEN, true);
 
     for (uint32_t frame = 0; frame < CONT_RX_FRAMES; frame++) {
         uint32_t before = rx_frame_success_count;

--- a/firmware/source/torque_vector/main.c
+++ b/firmware/source/torque_vector/main.c
@@ -76,9 +76,7 @@ int main(void) {
     if (false == PHAL_USART_init(GPS_USART, GPS_BAUD_RATE, PHAL_RCC_getAPB1ClockHz())) {
         HardFault_Handler();
     }
-    if (false == PHAL_USART_rx(GPS_USART, (uint8_t *)rover_rx_buffer, sizeof(rover_rx_buffer), true)) {
-        HardFault_Handler();
-    }
+    PHAL_USART_rx(GPS_USART, (uint8_t *)rover_rx_buffer, sizeof(rover_rx_buffer), true);
     PHAL_FDCAN_init(FDCAN2, VCAN_BAUD_RATE);
     CAN_init();
 


### PR DESCRIPTION
* DMA callback system: DMA owns all DMA IRQ handlers. Other HALs (SPI/USART/ADC) call `PHAL_DMA_initWithCallback` instead.
* USART and SPI HALs were updated to use the public DMA HAL API instead of implementing their own flag checkers/clearers
* DMA HAL does not check for nullptr handles. Matches other HALs implementations and allows simpler implementation and occasionally return types.
  * (HardFaulting due to null pointer deref is the correct behavior should you try to call a DMA HAL function on a null handle)
* Other HALs always check DMA return types
  * Or explicitly `(void)` them if is will always succeed
    * Other HALs return types can then be simplified