### PR TITLE
RTOS Wrapper fix for 0 period

### DIFF
--- a/firmware/common/rtos/rtos.c
+++ b/firmware/common/rtos/rtos.c
@@ -20,6 +20,11 @@ void RTOS_periodic_task_runner(void *arg) {
         wrapper->taskFunction();
         if (period_ticks > 0) {
             vTaskDelayUntil(&last_wake_time, period_ticks);
+        } else {
+            // Yields only to tasks with equal priority
+            // If the task is high priority and has no delay, it must block internally
+            // (ex: on a queue or notification)
+            taskYIELD();
         }
     }
 

--- a/firmware/common/rtos/rtos.c
+++ b/firmware/common/rtos/rtos.c
@@ -18,7 +18,9 @@ void RTOS_periodic_task_runner(void *arg) {
 
     while (true) {
         wrapper->taskFunction();
-        vTaskDelayUntil(&lastWakeTime, period);
+        if (period > 0) {
+            vTaskDelayUntil(&lastWakeTime, period);
+        }
     }
 
     // Unreachable!

--- a/firmware/common/rtos/rtos.c
+++ b/firmware/common/rtos/rtos.c
@@ -13,13 +13,13 @@
 void RTOS_periodic_task_runner(void *arg) {
     RTOS_periodic_task_params_t *wrapper = (RTOS_periodic_task_params_t *)arg;
 
-    TickType_t lastWakeTime = xTaskGetTickCount();
-    const TickType_t period = pdMS_TO_TICKS(wrapper->period_ms);
+    TickType_t last_wake_time = xTaskGetTickCount();
+    const TickType_t period_ticks = pdMS_TO_TICKS(wrapper->period_ms);
 
     while (true) {
         wrapper->taskFunction();
-        if (period > 0) {
-            vTaskDelayUntil(&lastWakeTime, period);
+        if (period_ticks > 0) {
+            vTaskDelayUntil(&last_wake_time, period_ticks);
         }
     }
 

--- a/firmware/source/g4_testing/canpiler_test.c
+++ b/firmware/source/g4_testing/canpiler_test.c
@@ -6,7 +6,7 @@
 #include "common/phal_G4/fdcan/fdcan.h"
 #include "common/phal_G4/gpio/gpio.h"
 #include "common/phal_G4/rcc/rcc.h"
-#include "common/freertos/freertos.h"
+#include "common/rtos/rtos.h"
 #include "common/utils/countof.h"
 #include "can_library/can_common.h"
 #include "can_library/generated/G4_TESTING.h"
@@ -44,7 +44,7 @@ void send_periodic() {
 }
 
 DEFINE_CAN_TASKS();
-FREERTOS_DEFINE_TASK(send_periodic, 100, TASK_PRIORITY_NORMAL, 512);
+RTOS_DEFINE_TASK(send_periodic, 100, TASK_PRIORITY_NORMAL, 512);
 
 int main() {
     PHAL_RCC_init(PHAL_RCC_HSI_16MHZ);
@@ -57,7 +57,7 @@ int main() {
     CAN_init();
 
     START_CAN_TASKS();  
-    FREERTOS_START_TASK(send_periodic);
+    RTOS_START_TASK(send_periodic);
 
     vTaskStartScheduler();
 


### PR DESCRIPTION
Previously 0 period would be passed directly passed to `vTaskDelayUntil` which would trigger `configASSERT( ( xTimeIncrement > 0U ) );` and halt. Now, the wrapper includes a guard:
```c
while (true) {
    wrapper->taskFunction();
    if (period_ticks > 0) {
        vTaskDelayUntil(&last_wake_time, period_ticks);
    } else {
        // Yields only to tasks with equal priority
        // If the task is high priority and has no delay, it must block internally
        // (ex: on a queue or notification)
        taskYIELD();
    }
}
```

Also updates to snake case variables. Also updated g4_testing canpiler_test to use `rtos` name instead of `freertos`.