### PR TITLE
CANpiler Baud Rate Enum

### DIFF
--- a/firmware/can_library/canpiler/codegen.py
+++ b/firmware/can_library/canpiler/codegen.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Optional, Any
 from parser import Node, Message, SystemContext
 from utils import GENERATED_DIR, print_as_success, print_as_ok, get_jinja_env, render_template
 
+
 @dataclass
 class SignalCodec:
     signal: Any

--- a/firmware/can_library/canpiler/codegen.py
+++ b/firmware/can_library/canpiler/codegen.py
@@ -9,6 +9,11 @@ from typing import List, Dict, Optional, Any
 from parser import Node, Message, SystemContext
 from utils import GENERATED_DIR, print_as_success, print_as_ok, get_jinja_env, render_template
 
+BAUD_RATE_LABELS = {
+    250000: "FDCAN_BAUD_250K",
+    500000: "FDCAN_BAUD_500K",
+    1000000: "FDCAN_BAUD_1M",
+}
 
 @dataclass
 class SignalCodec:
@@ -380,10 +385,17 @@ def generate_node_header(env, node: Node, context: SystemContext):
                     ctx=render_context)
     print_as_ok(f"Generated {filename.name}")
 
+def baud_rate_label(bus_name: str, baud_rate: int) -> str:
+    if baud_rate not in BAUD_RATE_LABELS:
+        raise ValueError(f"Bus '{bus_name}' has unsupported baud rate {baud_rate}")
+    return BAUD_RATE_LABELS[baud_rate]
+
 def generate_bus_header(env, bus_name: str, config: Dict, messages: List[Message]):
+    baud_label = baud_rate_label(bus_name, config["baud_rate"])
     render_template(env, 'bus_header.h.jinja',
                     GENERATED_DIR / f"{bus_name}.h",
                     bus_name=bus_name,
                     config=config,
+                    baud_label=baud_label,
                     messages=messages)
     print_as_ok(f"Generated {bus_name}.h")

--- a/firmware/can_library/canpiler/codegen.py
+++ b/firmware/can_library/canpiler/codegen.py
@@ -9,15 +9,6 @@ from typing import List, Dict, Optional, Any
 from parser import Node, Message, SystemContext
 from utils import GENERATED_DIR, print_as_success, print_as_ok, get_jinja_env, render_template
 
-# Supported CAN baud rates. Keep in sync with:
-# - baud_rate enum in bus.schema.json
-# - PHAL_FDCAN_BaudRate_t in phal_F4/can/can.h and phal_G4/can/can.h
-BAUD_RATE_LABELS = {
-    250000: "FDCAN_BAUD_250K",
-    500000: "FDCAN_BAUD_500K",
-    1000000: "FDCAN_BAUD_1M",
-}
-
 @dataclass
 class SignalCodec:
     signal: Any
@@ -388,17 +379,11 @@ def generate_node_header(env, node: Node, context: SystemContext):
                     ctx=render_context)
     print_as_ok(f"Generated {filename.name}")
 
-def baud_rate_label(bus_name: str, baud_rate: int) -> str:
-    if baud_rate not in BAUD_RATE_LABELS:
-        raise ValueError(f"Bus '{bus_name}' has unsupported baud rate {baud_rate}")
-    return BAUD_RATE_LABELS[baud_rate]
-
 def generate_bus_header(env, bus_name: str, config: Dict, messages: List[Message]):
-    baud_label = baud_rate_label(bus_name, config["baud_rate"])
     render_template(env, 'bus_header.h.jinja',
                     GENERATED_DIR / f"{bus_name}.h",
                     bus_name=bus_name,
                     config=config,
-                    baud_label=baud_label,
+                    baud_label=config["baud_label"],
                     messages=messages)
     print_as_ok(f"Generated {bus_name}.h")

--- a/firmware/can_library/canpiler/codegen.py
+++ b/firmware/can_library/canpiler/codegen.py
@@ -384,6 +384,5 @@ def generate_bus_header(env, bus_name: str, config: Dict, messages: List[Message
                     GENERATED_DIR / f"{bus_name}.h",
                     bus_name=bus_name,
                     config=config,
-                    baud_label=config["baud_label"],
                     messages=messages)
     print_as_ok(f"Generated {bus_name}.h")

--- a/firmware/can_library/canpiler/codegen.py
+++ b/firmware/can_library/canpiler/codegen.py
@@ -9,6 +9,9 @@ from typing import List, Dict, Optional, Any
 from parser import Node, Message, SystemContext
 from utils import GENERATED_DIR, print_as_success, print_as_ok, get_jinja_env, render_template
 
+# Supported CAN baud rates. Keep in sync with:
+# - baud_rate enum in bus.schema.json
+# - PHAL_FDCAN_BaudRate_t in phal_F4/can/can.h and phal_G4/can/can.h
 BAUD_RATE_LABELS = {
     250000: "FDCAN_BAUD_250K",
     500000: "FDCAN_BAUD_500K",

--- a/firmware/can_library/canpiler/parser.py
+++ b/firmware/can_library/canpiler/parser.py
@@ -14,6 +14,15 @@ from utils import (
     get_git_hash, get_layout_hash, print_as_warning
 )
 
+# Supported CAN baud rates. Keep in sync with:
+# - baud_rate enum in bus.schema.json
+# - PHAL_FDCAN_BaudRate_t in phal_F4/can/can.h and phal_G4/fdcan/fdcan.h
+BAUD_RATE_LABELS = {
+    250000: "FDCAN_BAUD_250K",
+    500000: "FDCAN_BAUD_500K",
+    1000000: "FDCAN_BAUD_1M",
+}
+
 @dataclass
 class Signal:
     name: str
@@ -325,11 +334,19 @@ def load_custom_types() -> Dict:
     except FileNotFoundError:
         return {}
 
+def baud_rate_label(bus_name: str, baud_rate: int) -> str:
+    if baud_rate not in BAUD_RATE_LABELS:
+        raise ValueError(f"Bus '{bus_name}' has unsupported baud rate {baud_rate}.")
+    return BAUD_RATE_LABELS[baud_rate]
+
 def load_bus_configs() -> Dict:
     """Load bus configurations from bus_configs.json"""
     try:
         data = load_json(BUS_CONFIG_PATH)
-        return {b["name"]: b for b in data.get("busses", [])}
+        configs = {b["name"]: b for b in data.get("busses", [])}
+        for name, cfg in configs.items():
+            cfg["baud_label"] = baud_rate_label(name, cfg["baud_rate"])
+        return configs
     except FileNotFoundError:
         return {}
 

--- a/firmware/can_library/canpiler/parser.py
+++ b/firmware/can_library/canpiler/parser.py
@@ -340,7 +340,7 @@ def baud_rate_label(bus_name: str, baud_rate: int) -> str:
     return BAUD_RATE_LABELS[baud_rate]
 
 def load_bus_configs() -> Dict:
-    """Load bus configurations from bus_configs.json"""
+    """Load bus configurations from bus_configs.json and attach each bus's baud rate enum label."""
     try:
         data = load_json(BUS_CONFIG_PATH)
         configs = {b["name"]: b for b in data.get("busses", [])}

--- a/firmware/can_library/configs/README.md
+++ b/firmware/can_library/configs/README.md
@@ -4,7 +4,7 @@
 Validated by `bus.schema.json`. Describes each logical CAN bus (not how a node attaches to it).
 
 - `name`: Logical bus name (referenced by nodes and external nodes).
-- `baud_rate`: CAN bitrate for this bus.
+- `baud_rate`: CAN bitrate for this bus. Must be '250000', '500000', or '1000000' (250k, 500k, 1M).
 - `is_extended_id`: Boolean. Mixed-ID buses are not supported; all messages on a bus share this framing.
 - `is_flexible_data_rate`: Boolean. Whether this bus uses CAN FD.
 - `host_fault_library`: Boolean. If true, this bus is the primary uplink for fault communication (usually VCAN).

--- a/firmware/can_library/schema/bus.schema.json
+++ b/firmware/can_library/schema/bus.schema.json
@@ -18,7 +18,7 @@
             "additionalProperties": false,
             "properties": {
                 "name": { "type": "string" },
-                "baud_rate": { "type": "integer" },
+                "baud_rate": { "type": "integer", "enum": [250000, 500000, 1000000] },
                 "is_extended_id": { "type": "boolean" },
                 "is_flexible_data_rate": { "type": "boolean" },
                 "host_fault_library": { "type": "boolean" }

--- a/firmware/can_library/templates/bus_header.h.jinja
+++ b/firmware/can_library/templates/bus_header.h.jinja
@@ -9,9 +9,10 @@
  */
 
 #include <stdint.h>
+#include "can_library/can_common.h"
 #include "can_library/generated/can_types.h"
 
-static constexpr uint32_t {{ bus_name|upper }}_BAUD_RATE = {{ config.baud_rate }};
+static constexpr PHAL_FDCAN_BaudRate_t {{ bus_name|upper }}_BAUD_RATE = {{ baud_label }};
 
 {% for msg in messages %}
 static constexpr uint32_t {{ msg.macro_name }}_MSG_ID = {{ msg.final_id|to_c_hex }};

--- a/firmware/can_library/templates/bus_header.h.jinja
+++ b/firmware/can_library/templates/bus_header.h.jinja
@@ -12,7 +12,7 @@
 #include "can_library/can_common.h"
 #include "can_library/generated/can_types.h"
 
-static constexpr PHAL_FDCAN_BaudRate_t {{ bus_name|upper }}_BAUD_RATE = {{ baud_label }};
+static constexpr PHAL_FDCAN_BaudRate_t {{ bus_name|upper }}_BAUD_RATE = {{ config.baud_label }};
 
 {% for msg in messages %}
 static constexpr uint32_t {{ msg.macro_name }}_MSG_ID = {{ msg.final_id|to_c_hex }};

--- a/firmware/common/phal_F4/can/can.h
+++ b/firmware/common/phal_F4/can/can.h
@@ -32,6 +32,14 @@
 #define PHAL_CAN_16MHz_250k (0x003a0003) // sample point = 75%
 #define PHAL_CAN_24MHz_250k (0x003a0005) // sample point = 75%
 #define PHAL_CAN_36MHz_250k (0x003a0008) // sample point = 75%
+/**
+ * @brief Supported baud rates for PER F4 FDCAN HAL.
+ */
+typedef enum : uint32_t {
+    FDCAN_BAUD_250K = 250000U,
+    FDCAN_BAUD_500K = 500000U,
+    FDCAN_BAUD_1M   = 1000000U
+} PHAL_FDCAN_BaudRate_t;
 
 /**
  * @brief Classic CAN frame

--- a/firmware/common/phal_F4/can/can.h
+++ b/firmware/common/phal_F4/can/can.h
@@ -33,7 +33,7 @@
 #define PHAL_CAN_24MHz_250k (0x003a0005) // sample point = 75%
 #define PHAL_CAN_36MHz_250k (0x003a0008) // sample point = 75%
 /**
- * @brief Supported baud rates for PER F4 FDCAN HAL.
+ * @brief Supported baud rates for PER F4 CAN HAL.
  */
 typedef enum : uint32_t {
     FDCAN_BAUD_250K = 250000U,


### PR DESCRIPTION
Generates each bus's baud rate as a typed `PHAL_FDCAN_BaudRate_t` constant instead of a raw `uint32_t`, and validates it against the supported rates.

* Adds `PHAL_FDCAN_BaudRate_t` to F4 CAN PHAL (`common/phal_F4/can/can.h`), a separate copy identical to the existing G4 enum in `phal_G4/fdcan/fdcan.h`. 
* Maps the configured rate to enum label in `codegen.py` and renders in `bus_header.h.jinja`.
* Adds `can_common.h` to the generated bus header so the enum resolves for files that include a bus header directly.
* Validates `baud_rate` against `[250000, 500000, 1000000]` in `bus.schema.json`. 