### PR TITLE
Add HIL out-of-range signal display

### DIFF
--- a/daqapp/src/hil/config.rs
+++ b/daqapp/src/hil/config.rs
@@ -1,14 +1,14 @@
 // Read HIL config files (preset and tests)
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 pub const PRESETS_FILE: &str = "hil_config/presets.json";
 pub const TESTS_FOLDER: &str = "hil_config/tests/";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct PresetsFile(pub HashMap<String, Vec<String>>);
+pub struct PresetsFile(pub IndexMap<String, Vec<String>>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestFile {
@@ -26,7 +26,7 @@ pub struct TxMessage {
     pub timestamp: f64,
     pub msg_name: String,
 
-    pub signals: HashMap<String, f64>,
+    pub signals: IndexMap<String, f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,7 +36,7 @@ pub struct Expectation {
     pub msg_name: String,
 
     #[serde(default)]
-    pub signals: HashMap<String, [f64; 2]>,
+    pub signals: IndexMap<String, [f64; 2]>,
 }
 
 #[derive(Clone)]

--- a/daqapp/src/hil/run.rs
+++ b/daqapp/src/hil/run.rs
@@ -11,9 +11,34 @@ pub enum ExpectResult {
     FailedValueOutOfRange,
 }
 
+/// Single signal failure, captured at evaluation used for displaying in the UI
+pub enum SignalFailure {
+    /// Signal present but value is out of range
+    OutOfRange {
+        name: String,
+        value: f64,
+        range: [f64; 2],
+    },
+    /// Signal missing from the message
+    MissingSignal {
+        name: String,
+        range: [f64; 2],
+    },
+}
+
+impl SignalFailure {
+    pub fn name(&self) -> &str {
+        match self {
+            SignalFailure::OutOfRange { name, .. } => name,
+            SignalFailure::MissingSignal { name, ..} => name,
+        }
+    }
+}
+
 pub struct InProgressExpect {
     pub expect: hil::config::Expectation,
     pub result: ExpectResult,
+    pub failures: Vec<SignalFailure>,
 }
 
 pub struct HilRunningTest {
@@ -111,26 +136,32 @@ impl HilRunningTest {
                 if expect.expect.signals.is_empty() {
                     expect.result = ExpectResult::Passed;
                 } else {
-                    let mut all_signals_in_range = true;
+                    let mut failures =  Vec::new();
                     for (sig_name, sig_range) in &expect.expect.signals {
-                        if let Some(sig_value) = parsed.decoded.signals.get(sig_name) {
-                            if sig_value.value.physical < sig_range[0]
-                                || sig_value.value.physical > sig_range[1]
-                            {
-                                all_signals_in_range = false;
-                                break;
+                        match parsed.decoded.signals.get(sig_name) {
+                            Some(sig_value) => {
+                                let value = sig_value.value.physical;
+                                if value < sig_range[0] || value > sig_range[1] {
+                                    failures.push(SignalFailure::OutOfRange {
+                                        name: sig_name.clone(),
+                                        value,
+                                        range: *sig_range,
+                                    });
+                                }
                             }
-                        } else {
-                            all_signals_in_range = false;
-                            break;
+                            None => failures.push(SignalFailure::MissingSignal {
+                                name: sig_name.clone(),
+                                range: *sig_range,
+                            }),
                         }
                     }
 
-                    expect.result = if all_signals_in_range {
+                    expect.result = if failures.is_empty() {
                         ExpectResult::Passed
                     } else {
                         ExpectResult::FailedValueOutOfRange
                     };
+                    expect.failures = failures;
                 }
             }
         }
@@ -164,6 +195,7 @@ impl InProgressExpect {
         Self {
             expect,
             result: ExpectResult::NotInWindow,
+            failures: Vec::new(),
         }
     }
 

--- a/daqapp/src/hil/run.rs
+++ b/daqapp/src/hil/run.rs
@@ -20,17 +20,14 @@ pub enum SignalFailure {
         range: [f64; 2],
     },
     /// Signal missing from the message
-    MissingSignal {
-        name: String,
-        range: [f64; 2],
-    },
+    MissingSignal { name: String, range: [f64; 2] },
 }
 
 impl SignalFailure {
     pub fn name(&self) -> &str {
         match self {
             SignalFailure::OutOfRange { name, .. } => name,
-            SignalFailure::MissingSignal { name, ..} => name,
+            SignalFailure::MissingSignal { name, .. } => name,
         }
     }
 }
@@ -136,7 +133,7 @@ impl HilRunningTest {
                 if expect.expect.signals.is_empty() {
                     expect.result = ExpectResult::Passed;
                 } else {
-                    let mut failures =  Vec::new();
+                    let mut failures = Vec::new();
                     for (sig_name, sig_range) in &expect.expect.signals {
                         match parsed.decoded.signals.get(sig_name) {
                             Some(sig_value) => {

--- a/daqapp/src/ui/hil.rs
+++ b/daqapp/src/ui/hil.rs
@@ -333,7 +333,10 @@ impl Hil {
                         Some(hil::run::SignalFailure::MissingSignal { range, .. }) => {
                             ui.colored_label(
                                 egui::Color32::RED,
-                                format!("{}: missing (expected [{}, {}])", name, range[0], range[1]),
+                                format!(
+                                    "{}: missing (expected [{}, {}])",
+                                    name, range[0], range[1]
+                                ),
                             );
                         }
                         None => {

--- a/daqapp/src/ui/hil.rs
+++ b/daqapp/src/ui/hil.rs
@@ -321,13 +321,27 @@ impl Hil {
         if ipe.expect.signals.is_empty() {
             ui.label("—");
         } else {
-            let s: Vec<String> = ipe
-                .expect
-                .signals
-                .iter()
-                .map(|(n, r)| format!("{}: [{}, {}]", n, r[0], r[1]))
-                .collect();
-            ui.label(s.join(", "));
+            ui.vertical(|ui| {
+                for (name, range) in &ipe.expect.signals {
+                    match ipe.failures.iter().find(|f| f.name() == name) {
+                        Some(hil::run::SignalFailure::OutOfRange { value, range, .. }) => {
+                            ui.colored_label(
+                                egui::Color32::RED,
+                                format!("{}: {} outside [{}, {}]", name, value, range[0], range[1]),
+                            );
+                        }
+                        Some(hil::run::SignalFailure::MissingSignal { range, .. }) => {
+                            ui.colored_label(
+                                egui::Color32::RED,
+                                format!("{}: missing (expected [{}, {}])", name, range[0], range[1]),
+                            );
+                        }
+                        None => {
+                            ui.label(format!("{}: [{}, {}]", name, range[0], range[1]));
+                        }
+                    }
+                }
+            });
         }
         ui.end_row();
     }


### PR DESCRIPTION
- Fixes the HIL results panel only showing "Failed (value out of range)" on a signal failure
- Checks every expected signal, recording the value and expected range for out-of-range and missing signals into a new SignalFailure list on InProgressExpect
- src/ui/hil.rs displays one line per expected signal in the Signals column, showing failures in red(name: <value> outside [min, max] for out-of-range and name: missing (expected [min, max]) for missing signals)
<img width="1065" height="726" alt="Screenshot 2026-09-01 at 1 07 55 PM" src="https://github.com/user-attachments/assets/3f82e5ed-9ceb-4c3c-a4cd-f53db3952bea" />
