### PR TITLE
Move HIL Engine to CAN Thread

### DIFF
--- a/daqapp/src/app.rs
+++ b/daqapp/src/app.rs
@@ -210,7 +210,8 @@ impl eframe::App for DAQApp {
                 messages::MsgFromCan::ParsedMessage(_)
                 | messages::MsgFromCan::UnparsedMessage(_)
                 | messages::MsgFromCan::MessageSent { .. }
-                | messages::MsgFromCan::BusLoad { .. } => {
+                | messages::MsgFromCan::BusLoad { .. }
+                | messages::MsgFromCan::Hil(_) => {
                     // Nothing special to do here, the message will be handled
                     // in the individual widgets
                 }

--- a/daqapp/src/app.rs
+++ b/daqapp/src/app.rs
@@ -1,6 +1,6 @@
 use crate::{
-    action, connection, formatter, messages, settings, shortcuts, theme, ui, util, widget_ids,
-    widgets, workspace,
+    action, connection, formatter, messages, settings, shortcuts, theme, ui, util,
+    widget_constructor, widget_ids, widgets, workspace,
 };
 use eframe::egui;
 
@@ -145,9 +145,21 @@ impl DAQApp {
     pub fn handle_action(&mut self, action: action::AppAction, ctx: &egui::Context) {
         match action {
             action::AppAction::SpawnWidget(widget_type) => {
+                let kind = widget_type.kind();
+                if kind == widget_constructor::WidgetKind::Hil
+                    && self
+                        .tile_tree
+                        .tiles
+                        .tiles()
+                        .any(|tile| matches!(tile, egui_tiles::Tile::Pane(widgets::Widget::Hil(_))))
+                {
+                    log::warn!("A HIL tab is already open; only one is allowed at a time");
+                    return;
+                }
                 let widget = widget_type.create(&mut self.widget_ids, self.ui_to_can_tx.clone());
                 self.add_widget_to_tree(widget);
             }
+
             action::AppAction::ToggleSidebar => {
                 self.is_sidebar_open = !self.is_sidebar_open;
             }

--- a/daqapp/src/can/state.rs
+++ b/daqapp/src/can/state.rs
@@ -12,6 +12,7 @@ pub struct State {
     pub last_bus_load_update: std::time::Instant,
     pub hil_engine: hil::engine::HilEngine,
     pub last_hil_update: std::time::Instant,
+    pub hil_finished_sent: bool,
 }
 
 pub struct SendMsgInfo {
@@ -45,6 +46,7 @@ impl State {
             last_bus_load_update: std::time::Instant::now(),
             hil_engine: hil::engine::HilEngine::new(),
             last_hil_update: std::time::Instant::now(),
+            hil_finished_sent: false,
         }
     }
 

--- a/daqapp/src/can/state.rs
+++ b/daqapp/src/can/state.rs
@@ -1,4 +1,4 @@
-use crate::{can, connection, messages};
+use crate::{can, connection, hil, messages};
 
 pub struct State {
     pub can_to_ui_tx: std::sync::mpsc::Sender<messages::MsgFromCan>,
@@ -10,6 +10,8 @@ pub struct State {
     pub send_msgs: std::collections::HashMap<u32, SendMsgInfo>, // msg_id -> SendMsg
     pub bus_load_tracker: can::bus_load::BusLoadTracker,
     pub last_bus_load_update: std::time::Instant,
+    pub hil_engine: hil::engine::HilEngine,
+    pub last_hil_update: std::time::Instant,
 }
 
 pub struct SendMsgInfo {
@@ -41,6 +43,8 @@ impl State {
             send_msgs: std::collections::HashMap::new(),
             bus_load_tracker: can::bus_load::BusLoadTracker::new(),
             last_bus_load_update: std::time::Instant::now(),
+            hil_engine: hil::engine::HilEngine::new(),
+            last_hil_update: std::time::Instant::now(),
         }
     }
 

--- a/daqapp/src/can/thread.rs
+++ b/daqapp/src/can/thread.rs
@@ -133,7 +133,7 @@ pub fn start_can_thread(
                     }
                 }
             }
-            
+
             state.hil_engine.tick();
             if state.hil_engine.is_running()
                 && state.last_hil_update.elapsed().as_millis() >= HIL_UPDATE_MS

--- a/daqapp/src/can/thread.rs
+++ b/daqapp/src/can/thread.rs
@@ -125,6 +125,7 @@ pub fn start_can_thread(
                     }
                     messages::MsgFromUi::Hil(command) => {
                         state.hil_engine.handle_command(command);
+                        state.hil_finished_sent = false;
                         state
                             .can_to_ui_tx
                             .send(messages::MsgFromCan::Hil(state.hil_engine.snapshot()))
@@ -136,6 +137,7 @@ pub fn start_can_thread(
 
             state.hil_engine.tick();
             if state.hil_engine.is_running()
+                && !state.hil_finished_sent
                 && state.last_hil_update.elapsed().as_millis() >= HIL_UPDATE_MS
             {
                 state
@@ -143,6 +145,7 @@ pub fn start_can_thread(
                     .send(messages::MsgFromCan::Hil(state.hil_engine.snapshot()))
                     .expect("Failed to send HIL snapshot");
                 state.last_hil_update = std::time::Instant::now();
+                state.hil_finished_sent = state.hil_engine.all_finished();
             }
 
             let msgs_to_send = state.send_this_tick();

--- a/daqapp/src/can/thread.rs
+++ b/daqapp/src/can/thread.rs
@@ -90,16 +90,6 @@ pub fn start_can_thread(
 
         // MAIN LOOP
         loop {
-            state.hil_engine.tick();
-            if state.hil_engine.is_running()
-                && state.last_hil_update.elapsed().as_millis() >= HIL_UPDATE_MS
-            {
-                state
-                    .can_to_ui_tx
-                    .send(messages::MsgFromCan::Hil(state.hil_engine.snapshot()))
-                    .expect("Failed to send HIL snapshot");
-                state.last_hil_update = std::time::Instant::now();
-            }
             // Process UI messages first (DBC load, new message to send, etc.)
             while let Ok(msg) = state.ui_to_can_rx.try_recv() {
                 match msg {
@@ -143,6 +133,18 @@ pub fn start_can_thread(
                     }
                 }
             }
+            
+            state.hil_engine.tick();
+            if state.hil_engine.is_running()
+                && state.last_hil_update.elapsed().as_millis() >= HIL_UPDATE_MS
+            {
+                state
+                    .can_to_ui_tx
+                    .send(messages::MsgFromCan::Hil(state.hil_engine.snapshot()))
+                    .expect("Failed to send HIL snapshot");
+                state.last_hil_update = std::time::Instant::now();
+            }
+
             let msgs_to_send = state.send_this_tick();
             for msg in msgs_to_send {
                 if let Some(ref mut active_driver) = state.driver {

--- a/daqapp/src/can/thread.rs
+++ b/daqapp/src/can/thread.rs
@@ -3,9 +3,10 @@ use crate::{can, connection, messages, util};
 const NO_CONNECTION_SLEEP_MS: u64 = 200;
 const READ_RETRY_SLEEP_MS: u64 = 2;
 const BUS_LOAD_UPDATE_MS: u128 = 200;
+const HIL_UPDATE_MS: u128 = 50;
 
 // Returns the number of payload data bytes in the CAN frame if it was a Can2 frame
-fn process_can_frame(frame: &slcan::CanFrame, state: &can::state::State) -> usize {
+fn process_can_frame(frame: &slcan::CanFrame, state: &mut can::state::State) -> usize {
     match frame {
         slcan::CanFrame::Can2(frame2) => {
             let decode_msg_id = util::can::slcan_to_u32_with_extid_flag(&frame2.id());
@@ -27,6 +28,7 @@ fn process_can_frame(frame: &slcan::CanFrame, state: &can::state::State) -> usiz
                         raw_bytes,
                         decoded,
                     };
+                    state.hil_engine.process_parsed(&parsed_msg);
                     state
                         .can_to_ui_tx
                         .send(messages::MsgFromCan::ParsedMessage(parsed_msg))
@@ -88,6 +90,16 @@ pub fn start_can_thread(
 
         // MAIN LOOP
         loop {
+            state.hil_engine.tick();
+            if state.hil_engine.is_running()
+                && state.last_hil_update.elapsed().as_millis() >= HIL_UPDATE_MS
+            {
+                state
+                    .can_to_ui_tx
+                    .send(messages::MsgFromCan::Hil(state.hil_engine.snapshot()))
+                    .expect("Failed to send HIL snapshot");
+                state.last_hil_update = std::time::Instant::now();
+            }
             // Process UI messages first (DBC load, new message to send, etc.)
             while let Ok(msg) = state.ui_to_can_rx.try_recv() {
                 match msg {
@@ -120,6 +132,14 @@ pub fn start_can_thread(
                     }
                     messages::MsgFromUi::UpdateLogFolder(path) => {
                         daq_logger.update_folder(path);
+                    }
+                    messages::MsgFromUi::Hil(command) => {
+                        state.hil_engine.handle_command(command);
+                        state
+                            .can_to_ui_tx
+                            .send(messages::MsgFromCan::Hil(state.hil_engine.snapshot()))
+                            .expect("Failed to send HIL snapshot");
+                        state.last_hil_update = std::time::Instant::now();
                     }
                 }
             }
@@ -235,7 +255,7 @@ pub fn start_can_thread(
             match active_driver.read_frames() {
                 Ok(frames) => {
                     for frame in frames {
-                        let data_bytes = process_can_frame(&frame, &state);
+                        let data_bytes = process_can_frame(&frame, &mut state);
                         state.bus_load_tracker.record_frame(data_bytes);
 
                         // Log each frame (buffered, not flushed yet)

--- a/daqapp/src/hil/engine.rs
+++ b/daqapp/src/hil/engine.rs
@@ -1,0 +1,154 @@
+use crate::{hil, messages};
+
+pub enum HilCommand {
+    StartTest(hil::config::TestInfo),
+    StartPreset(hil::config::PresetInfo),
+    Stop,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HilStatus {
+    Idle,
+    Running,
+}
+
+#[derive(Clone)]
+pub struct HilSnapshot {
+    pub status: HilStatus,
+    pub elapsed_ms: u128,
+    pub preset: Option<hil::config::PresetInfo>,
+    pub tests: Vec<hil::run::HilRunningTest>,
+    pub start_error: Option<String>,
+}
+
+impl HilSnapshot {
+    pub fn idle() -> Self {
+        Self {
+            status: HilStatus::Idle,
+            elapsed_ms: 0,
+            preset: None,
+            tests: Vec::new(),
+            start_error: None,
+        }
+    }
+}
+
+enum HilState {
+    Idle {
+        start_error: Option<String>,
+    },
+    Running {
+        start_time: std::time::Instant,
+        preset: Option<hil::config::PresetInfo>,
+        tests: Vec<hil::run::HilRunningTest>,
+    },
+}
+
+pub struct HilEngine {
+    state: HilState,
+}
+
+impl Default for HilEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HilEngine {
+    pub fn new() -> Self {
+        Self {
+            state: HilState::Idle { start_error: None },
+        }
+    }
+
+    pub fn is_running(&self) -> bool {
+        matches!(self.state, HilState::Running { .. })
+    }
+
+    pub fn handle_command(&mut self, command: HilCommand) {
+        match command {
+            HilCommand::StartTest(test_info) => match hil::run::HilRunningTest::new(&test_info) {
+                Ok(test) => self.begin(None, vec![test]),
+                Err(err) => self.fail_start(format!("Failed to start test: {err}")),
+            },
+
+            HilCommand::StartPreset(preset) => {
+                let mut tests = Vec::with_capacity(preset.tests.len());
+                for basename in &preset.tests {
+                    match hil::run::HilRunningTest::from_basename(basename) {
+                        Ok(test) => tests.push(test),
+                        Err(err) => {
+                            self.fail_start(format!("Failed to start test: {err}"));
+                            return;
+                        }
+                    }
+                }
+                self.begin(Some(preset), tests);
+            }
+            HilCommand::Stop => {
+                self.state = HilState::Idle { start_error: None };
+            }
+        }
+    }
+
+    pub fn process_parsed(&mut self, parsed: &messages::ParsedMessage) {
+        if let HilState::Running {
+            start_time, tests, ..
+        } = &mut self.state
+        {
+            for test in tests.iter_mut() {
+                test.process_can(parsed, *start_time);
+            }
+        }
+    }
+
+    pub fn tick(&mut self) {
+        if let HilState::Running {
+            start_time, tests, ..
+        } = &mut self.state
+        {
+            for test in tests.iter_mut() {
+                test.update_expect_statuses(*start_time);
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> HilSnapshot {
+        match &self.state {
+            HilState::Idle { start_error } => HilSnapshot {
+                status: HilStatus::Idle,
+                elapsed_ms: 0,
+                preset: None,
+                tests: Vec::new(),
+                start_error: start_error.clone(),
+            },
+            HilState::Running {
+                start_time,
+                preset,
+                tests,
+            } => HilSnapshot {
+                status: HilStatus::Running,
+                elapsed_ms: start_time.elapsed().as_millis(),
+                preset: preset.clone(),
+                tests: tests.clone(),
+                start_error: None,
+            },
+        }
+    }
+    fn begin(
+        &mut self,
+        preset: Option<hil::config::PresetInfo>,
+        tests: Vec<hil::run::HilRunningTest>,
+    ) {
+        self.state = HilState::Running {
+            start_time: std::time::Instant::now(),
+            preset,
+            tests,
+        };
+    }
+    fn fail_start(&mut self, message: String) {
+        self.state = HilState::Idle {
+            start_error: Some(message),
+        };
+    }
+}

--- a/daqapp/src/hil/engine.rs
+++ b/daqapp/src/hil/engine.rs
@@ -65,6 +65,13 @@ impl HilEngine {
         matches!(self.state, HilState::Running { .. })
     }
 
+    pub fn all_finished(&self) -> bool {
+        match &self.state {
+            HilState::Running { tests, .. } => tests.iter().all(|t| t.is_finished()),
+            HilState::Idle { .. } => false,
+        }
+    }
+
     pub fn handle_command(&mut self, command: HilCommand) {
         match command {
             HilCommand::StartTest(test_info) => match hil::run::HilRunningTest::new(&test_info) {

--- a/daqapp/src/hil/mod.rs
+++ b/daqapp/src/hil/mod.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod engine;
 pub mod run;

--- a/daqapp/src/hil/run.rs
+++ b/daqapp/src/hil/run.rs
@@ -2,7 +2,7 @@ use eframe::egui;
 
 use crate::{hil, messages};
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum ExpectResult {
     NotInWindow,
     InProgress,
@@ -12,6 +12,7 @@ pub enum ExpectResult {
 }
 
 /// Single signal failure, captured at evaluation used for displaying in the UI
+#[derive(Clone)]
 pub enum SignalFailure {
     /// Signal present but value is out of range
     OutOfRange {
@@ -32,25 +33,18 @@ impl SignalFailure {
     }
 }
 
+#[derive(Clone)]
 pub struct InProgressExpect {
     pub expect: hil::config::Expectation,
     pub result: ExpectResult,
     pub failures: Vec<SignalFailure>,
 }
 
+#[derive(Clone)]
 pub struct HilRunningTest {
     pub test_info: hil::config::TestInfo,
     pub tx_remaining: Vec<hil::config::TxMessage>,
     pub in_progress_expects: Vec<InProgressExpect>,
-}
-
-pub enum HilState {
-    Idle,
-    Running {
-        start_time: std::time::Instant,
-        preset_info: Option<hil::config::PresetInfo>,
-        tests: Vec<HilRunningTest>,
-    },
 }
 
 impl ExpectResult {
@@ -88,17 +82,31 @@ impl ExpectResult {
 impl HilRunningTest {
     pub fn new(test_info: &hil::config::TestInfo) -> Result<Self, String> {
         let test = hil::config::load_test_from_file(&test_info.basename)?;
+        Ok(Self::from_parts(test_info.clone(), test))
+    }
+
+    pub fn from_basename(basename: &str) -> Result<Self, String> {
+        let test = hil::config::load_test_from_file(basename)?;
+        let test_info = hil::config::TestInfo {
+            basename: basename.to_string(),
+            name: test.name.clone(),
+            description: test.description.clone(),
+        };
+        Ok(Self::from_parts(test_info, test))
+    }
+
+    pub fn from_parts(test_info: hil::config::TestInfo, test: hil::config::TestFile) -> Self {
         let mut in_progress_expects = test
             .expect
             .into_iter()
             .map(InProgressExpect::new)
             .collect::<Vec<_>>();
         in_progress_expects.sort_by(|a, b| a.expect.window[0].total_cmp(&b.expect.window[0]));
-        Ok(Self {
-            test_info: test_info.clone(),
+        Self {
+            test_info,
             tx_remaining: test.tx,
             in_progress_expects,
-        })
+        }
     }
 
     pub fn update_expect_statuses(&mut self, start_time: std::time::Instant) {

--- a/daqapp/src/messages.rs
+++ b/daqapp/src/messages.rs
@@ -1,4 +1,4 @@
-use crate::connection;
+use crate::{connection, hil};
 
 pub enum MsgFromUi {
     DbcSelected(std::path::PathBuf),
@@ -6,6 +6,7 @@ pub enum MsgFromUi {
     AddSendMessage(AddSendMessage),
     DeleteSendMessage { msg_id: u32 },
     UpdateLogFolder(std::path::PathBuf),
+    Hil(hil::engine::HilCommand),
 }
 
 pub enum MsgFromCan {
@@ -25,6 +26,7 @@ pub enum MsgFromCan {
         load_10s: f32,
         load_30s: f32,
     },
+    Hil(hil::engine::HilSnapshot),
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/daqapp/src/ui/hil.rs
+++ b/daqapp/src/ui/hil.rs
@@ -296,3 +296,9 @@ impl Hil {
         ui.end_row();
     }
 }
+
+impl Drop for Hil {
+    fn drop(&mut self) {
+        self.send_command(hil::engine::HilCommand::Stop);
+    }
+}

--- a/daqapp/src/ui/hil.rs
+++ b/daqapp/src/ui/hil.rs
@@ -44,6 +44,7 @@ impl Hil {
         self.found_presets = presets;
         self.found_tests = tests;
         self.load_errors = errors;
+        self.snapshot.start_error = None;
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {

--- a/daqapp/src/ui/hil.rs
+++ b/daqapp/src/ui/hil.rs
@@ -6,12 +6,15 @@ pub struct Hil {
     pub found_presets: Vec<hil::config::PresetInfo>,
     pub found_tests: Vec<hil::config::TestInfo>,
     pub load_errors: Vec<String>,
-    pub start_error: Option<String>,
-    pub hil_state: hil::run::HilState,
+    pub snapshot: hil::engine::HilSnapshot,
+    ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
 }
 
 impl Hil {
-    pub fn new(instance_num: usize) -> Self {
+    pub fn new(
+        instance_num: usize,
+        ui_to_can_tx: std::sync::mpsc::Sender<messages::MsgFromUi>,
+    ) -> Self {
         let (presets, tests, errors) = hil::config::list_available_tests();
 
         Self {
@@ -19,20 +22,20 @@ impl Hil {
             found_presets: presets,
             found_tests: tests,
             load_errors: errors,
-            start_error: None,
-            hil_state: hil::run::HilState::Idle,
+            snapshot: hil::engine::HilSnapshot::idle(),
+            ui_to_can_tx,
         }
     }
 
     pub fn handle_can_message(&mut self, msg: &messages::MsgFromCan) {
-        if let messages::MsgFromCan::ParsedMessage(parsed) = msg
-            && let hil::run::HilState::Running {
-                start_time, tests, ..
-            } = &mut self.hil_state
-        {
-            for test in tests {
-                test.process_can(parsed, *start_time);
-            }
+        if let messages::MsgFromCan::Hil(snapshot) = msg {
+            self.snapshot = snapshot.clone();
+        }
+    }
+
+    fn send_command(&self, command: hil::engine::HilCommand) {
+        if let Err(e) = self.ui_to_can_tx.send(messages::MsgFromUi::Hil(command)) {
+            log::error!("Failed to send HIL command to CAN thread: {e}");
         }
     }
 
@@ -41,167 +44,111 @@ impl Hil {
         self.found_presets = presets;
         self.found_tests = tests;
         self.load_errors = errors;
-        self.start_error = None;
-    }
-
-    fn try_start_from_test(&mut self, test: &hil::config::TestInfo) {
-        self.start_error = None;
-
-        let test = match hil::run::HilRunningTest::new(test) {
-            Ok(test) => test,
-            Err(err) => {
-                self.start_error = Some(format!("Error starting test: {}", err));
-                return;
-            }
-        };
-
-        self.hil_state = hil::run::HilState::Running {
-            start_time: std::time::Instant::now(),
-            preset_info: None,
-            tests: vec![test],
-        };
-    }
-
-    fn try_start_from_preset(&mut self, preset: &hil::config::PresetInfo) {
-        self.start_error = None;
-
-        let mut tests = Vec::new();
-        for test_name in &preset.tests {
-            let test_info = match self.found_tests.iter().find(|t| t.basename == *test_name) {
-                Some(info) => info,
-                None => {
-                    self.start_error = Some(format!(
-                        "Error starting preset: Test '{}' not found",
-                        test_name
-                    ));
-                    return;
-                }
-            };
-            let test = match hil::run::HilRunningTest::new(test_info) {
-                Ok(test) => test,
-                Err(err) => {
-                    self.start_error = Some(format!("Error starting preset: {}", err));
-                    return;
-                }
-            };
-            tests.push(test);
-        }
-
-        self.hil_state = hil::run::HilState::Running {
-            start_time: std::time::Instant::now(),
-            preset_info: Some(preset.clone()),
-            tests,
-        };
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) -> egui_tiles::UiResponse {
-        let mut idle_requested = false;
-
-        egui::ScrollArea::vertical().show(ui, |ui| match &mut self.hil_state {
-            hil::run::HilState::Idle => {
-                ui.label("HIL is idle. Select a preset or test to run.");
-                if ui.button("Reload Tests").clicked() {
-                    self.reload_tests();
-                }
-                ui.separator();
-                if !self.load_errors.is_empty() {
-                    ui.label("Errors loading tests:");
-                    for err in &self.load_errors {
-                        ui.label(format!("- {}", err));
-                    }
-                    ui.separator();
-                }
-
-                if let Some(err) = &self.start_error {
-                    ui.colored_label(egui::Color32::RED, err);
-                    ui.separator();
-                }
-
-                if !self.found_presets.is_empty() {
-                    ui.label("Presets:");
-                    let mut selected_preset = None;
-                    for preset in &self.found_presets {
-                        let preset_info = format!("{} - {}", preset.name, preset.tests.join(", "));
-                        if ui.button(&preset_info).clicked() {
-                            selected_preset = Some(preset.clone());
-                        }
-                    }
-                    if let Some(preset) = selected_preset {
-                        self.try_start_from_preset(&preset);
-                    }
-                    ui.separator();
-                }
-                if !self.found_tests.is_empty() {
-                    ui.label("Individual Tests:");
-                    let mut selected_test = None;
-                    for test in &self.found_tests {
-                        let test_info =
-                            format!("{} [{}]: {}", test.name, test.basename, test.description);
-                        if ui.button(&test_info).clicked() {
-                            selected_test = Some(test.clone());
-                        }
-                    }
-                    if let Some(test) = selected_test {
-                        self.try_start_from_test(&test);
-                    }
-                }
+        egui::ScrollArea::vertical().show(ui, |ui| match self.snapshot.status {
+            hil::engine::HilStatus::Idle => {
+                self.show_idle(ui);
             }
-            hil::run::HilState::Running {
-                start_time,
-                preset_info,
-                tests,
-            } => {
-                // Actually run the test
-                tests
-                    .iter_mut()
-                    .for_each(|t| t.update_expect_statuses(*start_time));
-                let all_finished = tests.iter().all(|t| t.is_finished());
-
-                ui.add_space(4.0);
-                if all_finished {
-                    // ui.label("HIL finished! Review the results below.");
-                    ui.horizontal(|ui| {
-                        if ui.button("Exit").clicked() {
-                            idle_requested = true;
-                        }
-                        ui.label("HIL finished! Review the results below.");
-                    });
-                } else {
-                    ui.horizontal(|ui| {
-                        if ui.button("Stop").clicked() {
-                            idle_requested = true;
-                        }
-                        let time_since_start = start_time.elapsed().as_millis();
-                        ui.label(format!(
-                            "HIL is running... {:.0} ms since start",
-                            time_since_start
-                        ));
-                    });
-                }
-                ui.separator();
-
-                if let Some(preset) = preset_info {
-                    ui.label(format!(
-                        "Preset: {} ({} tests)",
-                        preset.name,
-                        preset.tests.len()
-                    ));
-                    Self::show_preset_summary(ui, tests);
-                }
-                ui.separator();
-
-                for test in tests {
-                    Self::show_test(ui, test);
-                    ui.separator();
-                }
+            hil::engine::HilStatus::Running => {
+                self.show_running(ui);
             }
         });
 
-        if idle_requested {
-            self.hil_state = hil::run::HilState::Idle;
+        egui_tiles::UiResponse::None
+    }
+
+    fn show_idle(&mut self, ui: &mut egui::Ui) {
+        ui.label("HIL is idle. Select a preset or test to start.");
+        if ui.button("Reload Tests").clicked() {
+            self.reload_tests();
+        }
+        ui.separator();
+
+        if !self.load_errors.is_empty() {
+            ui.label("Errors loading tests:");
+            for error in &self.load_errors {
+                ui.label(format!("- {}", error));
+            }
+            ui.separator();
         }
 
-        egui_tiles::UiResponse::None
+        if let Some(error) = &self.snapshot.start_error {
+            ui.colored_label(egui::Color32::RED, error);
+            ui.separator();
+        }
+
+        if !self.found_presets.is_empty() {
+            ui.label(" Presets:");
+            let mut selected_preset = None;
+            for preset in &self.found_presets {
+                let preset_info = format!("{} - {}", preset.name, preset.tests.join(", "));
+                if ui.button(&preset_info).clicked() {
+                    selected_preset = Some(preset.clone());
+                }
+            }
+            if let Some(preset) = selected_preset {
+                self.send_command(hil::engine::HilCommand::StartPreset(preset));
+            }
+            ui.separator();
+        }
+        if !self.found_tests.is_empty() {
+            ui.label(" Individual Tests:");
+            let mut selected_test = None;
+            for test in &self.found_tests {
+                let test_info = format!("{} [{}]: {}", test.name, test.basename, test.description);
+                if ui.button(&test_info).clicked() {
+                    selected_test = Some(test.clone());
+                }
+            }
+            if let Some(test) = selected_test {
+                self.send_command(hil::engine::HilCommand::StartTest(test));
+            }
+        }
+    }
+
+    fn show_running(&mut self, ui: &mut egui::Ui) {
+        let tests = &self.snapshot.tests;
+        let all_finished = tests.iter().all(|t| t.is_finished());
+        let mut stop_requested = false;
+
+        ui.add_space(4.0);
+        if all_finished {
+            ui.horizontal(|ui| {
+                if ui.button("Exit").clicked() {
+                    stop_requested = true;
+                }
+                ui.label("HIL finished. Review results below.");
+            });
+        } else {
+            ui.horizontal(|ui| {
+                if ui.button("Stop").clicked() {
+                    stop_requested = true;
+                }
+                ui.label(format!("HIL running for {} ms", self.snapshot.elapsed_ms));
+            });
+        }
+        ui.separator();
+
+        if let Some(preset) = &self.snapshot.preset {
+            ui.label(format!(
+                "Preset: {} ({} tests)",
+                preset.name,
+                preset.tests.len()
+            ));
+            Self::show_preset_summary(ui, tests);
+        }
+        ui.separator();
+
+        for test in tests {
+            Self::show_test(ui, test);
+            ui.separator();
+        }
+
+        if stop_requested {
+            self.send_command(hil::engine::HilCommand::Stop);
+        }
     }
 
     fn show_preset_summary(ui: &mut egui::Ui, tests: &[hil::run::HilRunningTest]) {

--- a/daqapp/src/widget_constructor.rs
+++ b/daqapp/src/widget_constructor.rs
@@ -105,7 +105,7 @@ impl WidgetConstructor {
                 widgets::Widget::Dynamics(ui::dynamics::Dynamics::new(id))
             }
             WidgetConstructor::Jitter => widgets::Widget::Jitter(ui::jitter::Jitter::new(id)),
-            WidgetConstructor::Hil => widgets::Widget::Hil(ui::hil::Hil::new(id)),
+            WidgetConstructor::Hil => widgets::Widget::Hil(ui::hil::Hil::new(id, ui_to_can_tx)),
         }
     }
 }


### PR DESCRIPTION
- moves HIL engine from UI thread to CAN thread, so it keeps updating even when tab isn't in view
- engine logic in HilEngine struct 